### PR TITLE
Mobile friendly album thumbnails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -108,11 +108,12 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "9f2776ead772134d55b62dd45e59a79e21612d85d0af729b8b7d3967d601a62a"
 dependencies = [
  "concurrent-queue",
+ "event-listener 5.3.0",
  "event-listener-strategy 0.5.2",
  "futures-core",
  "pin-project-lite",
@@ -215,7 +216,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -250,7 +251,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -349,7 +350,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -407,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a6c0b39c38fd754ac338b00a88066436389c0f029da5d37d1e01091d9b7c17"
+checksum = "41bfbdb21256b87a8b5e80fab81a8eed158178e812fd7ba451907518b2742f16"
 
 [[package]]
 name = "bumpalo"
@@ -457,7 +458,7 @@ checksum = "b2ac2a4d0e69036cf0062976f6efcba1aaee3e448594e6514bb2ddf87acce562"
 dependencies = [
  "bitflags 2.5.0",
  "cairo-sys-rs 0.19.2",
- "glib 0.19.7",
+ "glib 0.19.6",
  "libc",
  "thiserror",
 ]
@@ -486,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
 dependencies = [
  "jobserver",
  "libc",
@@ -583,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -611,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -671,7 +672,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -691,9 +692,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "endi"
@@ -719,7 +720,7 @@ checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -965,7 +966,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1106,7 +1107,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1175,7 +1176,7 @@ checksum = "f6a23f8a0b5090494fd04924662d463f8386cc678dd3915015a838c1a3679b92"
 dependencies = [
  "gdk-pixbuf-sys 0.19.5",
  "gio 0.19.5",
- "glib 0.19.7",
+ "glib 0.19.6",
  "libc",
 ]
 
@@ -1232,7 +1233,7 @@ dependencies = [
  "gdk-pixbuf 0.19.2",
  "gdk4-sys",
  "gio 0.19.5",
- "glib 0.19.7",
+ "glib 0.19.6",
  "libc",
  "pango 0.19.5",
 ]
@@ -1343,7 +1344,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "gio-sys 0.19.5",
- "glib 0.19.7",
+ "glib 0.19.6",
  "libc",
  "pin-project-lite",
  "smallvec",
@@ -1401,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.19.7"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52355166df21c7ed16b6a01f615669c7911ed74e27ef60eba339c0d2da12490"
+checksum = "b0116c428e4841cab183a32a71b900fd6712194c20f9c424f01d2c016c96bd23"
 dependencies = [
  "bitflags 2.5.0",
  "futures-channel",
@@ -1412,7 +1413,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "gio-sys 0.19.5",
- "glib-macros 0.19.7",
+ "glib-macros 0.19.5",
  "glib-sys 0.19.5",
  "gobject-sys 0.19.5",
  "libc",
@@ -1432,20 +1433,20 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.19.7"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70025dbfa1275cf7d0531c3317ba6270dae15d87e63342229d638246ff45202e"
+checksum = "6ed782fa3e949c31146671da6e7a227a5e7d354660df1db6d0aac4974dc82a3c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1541,7 +1542,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e4d388e96c5f29e2b2f67045d229ddf826d0a8d6d282f94ed3b34452222c91"
 dependencies = [
- "glib 0.19.7",
+ "glib 0.19.6",
  "graphene-sys",
  "libc",
 ]
@@ -1566,7 +1567,7 @@ checksum = "7563884bf6939f4468e5d94654945bdd9afcaf8c3ba4c5dd17b5342b747221be"
 dependencies = [
  "cairo-rs 0.19.4",
  "gdk4",
- "glib 0.19.7",
+ "glib 0.19.6",
  "graphene-rs",
  "gsk4-sys",
  "libc",
@@ -1638,7 +1639,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1653,7 +1654,7 @@ dependencies = [
  "gdk-pixbuf 0.19.2",
  "gdk4",
  "gio 0.19.5",
- "glib 0.19.7",
+ "glib 0.19.6",
  "graphene-rs",
  "gsk4",
  "gtk4-macros",
@@ -1671,7 +1672,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1764,7 +1765,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "toml 0.8.13",
+ "toml 0.8.12",
  "unic-langid",
 ]
 
@@ -1807,7 +1808,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.65",
+ "syn 2.0.63",
  "unic-langid",
 ]
 
@@ -1821,7 +1822,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1914,7 +1915,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2043,7 +2044,7 @@ dependencies = [
  "gdk-pixbuf 0.19.2",
  "gdk4",
  "gio 0.19.5",
- "glib 0.19.7",
+ "glib 0.19.6",
  "gtk4",
  "libadwaita-sys",
  "libc",
@@ -2068,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2130,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "litrs"
@@ -2247,9 +2248,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
  "simd-adler32",
@@ -2350,7 +2351,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2472,7 +2473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504ce6e805439ea2c6791168fe7ef8e3da0c1b2ef82c44bc450dbc330592920d"
 dependencies = [
  "gio 0.19.5",
- "glib 0.19.7",
+ "glib 0.19.6",
  "libc",
  "pango-sys 0.19.5",
 ]
@@ -2665,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2688,7 +2689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2849,7 +2850,7 @@ dependencies = [
  "siphasher",
  "thiserror",
  "time",
- "toml 0.8.13",
+ "toml 0.8.12",
  "url",
  "walkdir",
 ]
@@ -2865,7 +2866,7 @@ dependencies = [
  "quote",
  "refinery-core",
  "regex",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2937,7 +2938,7 @@ checksum = "0774e846889823aa5766f5b62cface3189a5b36280e65b2faaa6df0319da1726"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2984,7 +2985,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.65",
+ "syn 2.0.63",
  "walkdir",
 ]
 
@@ -3034,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
 
 [[package]]
 name = "same-file"
@@ -3076,22 +3077,22 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.201"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3102,14 +3103,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -3236,7 +3237,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3246,14 +3247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.65"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3269,7 +3271,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.8.13",
+ "toml 0.8.12",
  "version-compare",
 ]
 
@@ -3299,22 +3301,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3415,21 +3417,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.13",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -3469,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap",
  "serde",
@@ -3499,7 +3501,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3691,7 +3693,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
  "wasm-bindgen-shared",
 ]
 
@@ -3713,7 +3715,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3873,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.2.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989c3977a7aafa97b12b9a35d21cdcff9b0d2289762b14683f45d66b1ba6c48f"
+checksum = "e5915716dff34abef1351d2b10305b019c8ef33dcf6c72d31a6e227d5d9d7a21"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -3911,14 +3913,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.2.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe9de53245dcf426b7be226a4217dd5e339080e5d46e64a02d6e5dcbf90fca1"
+checksum = "66fceb36d0c1c4a6b98f3ce40f410e64e5a134707ed71892e1b178abc4c695d4"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 1.0.109",
  "zvariant_utils",
 ]
 
@@ -3950,7 +3952,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3979,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.1.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa6d31a02fbfb602bfde791de7fedeb9c2c18115b3d00f3a36e489f46ffbbc7"
+checksum = "877ef94e5e82b231d2a309c531f191a8152baba8241a7939ee04bd76b0171308"
 dependencies = [
  "endi",
  "enumflags2",
@@ -3992,24 +3994,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "4.1.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642bf1b6b6d527988b3e8193d20969d53700a36eac734d21ae6639db168701c8"
+checksum = "b7ca98581cc6a8120789d8f1f0997e9053837d6aa5346cbb43454d7121be6e39"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 1.0.109",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "2.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc242db087efc22bd9ade7aa7809e4ba828132edc312871584a6b4391bdf8786"
+checksum = "75fa7291bdd68cd13c4f97cc9d78cbf16d96305856dfc7ac942aeff4c2de7d5a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.65",
+ "syn 1.0.109",
 ]

--- a/data/app.fotema.Fotema.metainfo.xml.in.in
+++ b/data/app.fotema.Fotema.metainfo.xml.in.in
@@ -128,10 +128,15 @@
 
   <launchable type="desktop-id">@app-id@.desktop</launchable>
 
+  <requires>
+    <!-- Minimum width defined in src/app.rs -->
+    <display_length compare="ge">360</display_length>
+  </requires>
+
   <recommends>
     <control>keyboard</control>
     <control>pointing</control>
+    <control>touch</control>
     <memory>2048</memory>
   </recommends>
-
 </component>

--- a/fotema.doap
+++ b/fotema.doap
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: © 2024 David Bliss -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <Project xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/"
          xmlns:gnome="http://api.gnome.org/doap-extensions#" xmlns="http://usefulinc.com/ns/doap#">

--- a/fotema.doap
+++ b/fotema.doap
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:gnome="http://api.gnome.org/doap-extensions#" xmlns="http://usefulinc.com/ns/doap#">
+  <name xml:lang="en">Fotema</name>
+  <shortdesc xml:lang="en">Photo Gallery</shortdesc>
+  <description xml:lang="en">Photo Gallery</description>
+
+  <homepage rdf:resource="https://github.com/blissd/fotema" />
+  <download-page rdf:resource="https://flathub.org/apps/app.fotema.Fotema" />
+  <bug-database rdf:resource="https://github.com/blissd/fotema/issues" />
+
+  <programming-language>Rust</programming-language>
+  <platform>GTK 4</platform>
+  <platform>Libadwaita</platform>
+
+  <maintainer>
+    <foaf:Person>
+      <foaf:name>David Bliss</foaf:name>
+      <foaf:mbox rdf:resource="mailto:hello@fotema.app" />
+    </foaf:Person>
+  </maintainer>
+</Project>
+

--- a/src/app.rs
+++ b/src/app.rs
@@ -442,7 +442,7 @@ impl SimpleComponent for App {
             });
 
         let library = Library::builder()
-            .launch((state.clone(), active_view.clone()))
+            .launch((state.clone(), active_view.clone(), adaptive_layout.clone()))
             .forward(sender.input_sender(), |msg| match msg {
                 LibraryOutput::View(id) => AppMsg::View(id, AlbumFilter::All),
             });

--- a/src/app.rs
+++ b/src/app.rs
@@ -143,6 +143,8 @@ pub(super) struct App {
 
 #[derive(Debug)]
 pub(super) enum AppMsg {
+    Activate(i32),
+
     Quit,
 
     // Toggle visibility of sidebar
@@ -195,6 +197,7 @@ impl SimpleComponent for App {
     }
 
     view! {
+        #[root]
         main_window = adw::ApplicationWindow::new(&main_application()) {
             set_visible: true,
 
@@ -206,6 +209,9 @@ impl SimpleComponent for App {
                 sender.input(AppMsg::Quit);
                 glib::Propagation::Stop
             },
+
+            // Notifies initial width of window so we can set correct adaptive layout for widgets
+            connect_is_active_notify => AppMsg::Activate(root.width()),
 
             add_css_class?: if PROFILE == "Devel" {
                     Some("devel")
@@ -466,6 +472,7 @@ impl SimpleComponent for App {
             });
 
         state.subscribe(selfies_page.sender(), |_| AlbumInput::Refresh);
+        adaptive_layout.subscribe(selfies_page.sender(), |layout| AlbumInput::Adapt(*layout));
 
         let show_selfies = AppWidgets::show_selfies();
 
@@ -476,6 +483,7 @@ impl SimpleComponent for App {
             });
 
         state.subscribe(motion_page.sender(), |_| AlbumInput::Refresh);
+        adaptive_layout.subscribe(motion_page.sender(), |layout| AlbumInput::Adapt(*layout));
 
         let videos_page = Album::builder()
             .launch((state.clone(), active_view.clone(), ViewName::Videos, AlbumFilter::Videos))
@@ -484,6 +492,7 @@ impl SimpleComponent for App {
             });
 
         state.subscribe(videos_page.sender(), |_| AlbumInput::Refresh);
+        adaptive_layout.subscribe(videos_page.sender(), |layout| AlbumInput::Adapt(*layout));
 
         let folders_album = FoldersAlbum::builder()
             .launch((state.clone(), active_view.clone()))
@@ -503,6 +512,7 @@ impl SimpleComponent for App {
             });
 
         state.subscribe(folder_album.sender(), |_| AlbumInput::Refresh);
+        adaptive_layout.subscribe(folder_album.sender(), |layout| AlbumInput::Adapt(*layout));
 
         let about_dialog = AboutDialog::builder().launch(root.clone()).detach();
 
@@ -589,8 +599,15 @@ impl SimpleComponent for App {
         ComponentParts { model, widgets }
     }
 
-    fn update(&mut self, message: Self::Input, _sender: ComponentSender<Self>) {
+    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
         match message {
+            AppMsg::Activate(width) => {
+                if width >= 500 {
+                    sender.input(AppMsg::Adapt(adaptive::Layout::Wide));
+                } else {
+                    sender.input(AppMsg::Adapt(adaptive::Layout::Narrow));
+                }
+            },
             AppMsg::Quit => main_application().quit(),
             AppMsg::ToggleSidebar => {
                 let show = self.main_navigation.shows_sidebar();

--- a/src/app/components/albums/album.rs
+++ b/src/app/components/albums/album.rs
@@ -16,6 +16,7 @@ use relm4::*;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::app::adaptive;
 use crate::app::SharedState;
 use crate::app::ActiveView;
 use crate::app::ViewName;
@@ -44,6 +45,9 @@ pub enum AlbumInput {
 
     // Show no photos
     Filter(AlbumFilter),
+
+    // Adapt to layout
+    Adapt(adaptive::Layout),
 }
 
 #[derive(Debug)]
@@ -267,7 +271,13 @@ impl SimpleComponent for Album {
                     event!(Level::DEBUG, "Scrolling to {}", index);
                     self.photo_grid.view.scroll_to(index, flags, None);
                 }
-            }
+            },
+            AlbumInput::Adapt(adaptive::Layout::Narrow) => {
+                event!(Level::DEBUG, "Adapt narrow");
+            },
+            AlbumInput::Adapt(adaptive::Layout::Wide) => {
+                event!(Level::DEBUG, "Adapt wide");
+            },
         }
     }
 }

--- a/src/app/components/albums/album.rs
+++ b/src/app/components/albums/album.rs
@@ -210,8 +210,6 @@ pub struct Album {
 }
 
 pub struct AlbumWidgets {
-    grid_view: gtk::GridView,
-
     // All pictures referenced by grid view.
     item_pictures: Rc<RwLock<HashSet<gtk::Picture>>>,
 }
@@ -255,10 +253,7 @@ impl SimpleComponent for Album {
 
         model.update_filter();
 
-        let grid_view = &model.photo_grid.view;
-
         let widgets = AlbumWidgets {
-            grid_view: grid_view.clone(),
             item_pictures: model.item_pictures.clone(),
         };
 
@@ -322,8 +317,8 @@ impl SimpleComponent for Album {
             adaptive::Layout::Narrow => {
                 let pics = widgets.item_pictures.write().expect("Lock to adapt narrow");
                 for pic in pics.iter() {
-                    pic.set_width_request(110);
-                    pic.set_height_request(110);
+                    pic.set_width_request(112);
+                    pic.set_height_request(112);
                 }
             },
             adaptive::Layout::Wide => {

--- a/src/app/components/albums/folders_album.rs
+++ b/src/app/components/albums/folders_album.rs
@@ -62,7 +62,9 @@ impl RelmGridItem for PhotoGridItem {
                     gtk::Frame {
                         #[name(picture)]
                         gtk::Picture {
-                            set_can_shrink: false,
+                            set_can_shrink: true,
+                            set_width_request: 170,
+                            set_height_request: 170,
                         }
                     }
                 },

--- a/src/app/components/albums/months_album.rs
+++ b/src/app/components/albums/months_album.rs
@@ -83,7 +83,9 @@ impl RelmGridItem for PhotoGridItem {
                         #[wrap(Some)]
                         #[name(picture)]
                         set_child = &gtk::Picture {
-                            set_can_shrink: false,
+                            set_can_shrink: true,
+                            set_width_request: 170,
+                            set_height_request: 170,
                         }
                     }
                 }

--- a/src/app/components/albums/years_album.rs
+++ b/src/app/components/albums/years_album.rs
@@ -75,7 +75,9 @@ impl RelmGridItem for PhotoGridItem {
                         #[wrap(Some)]
                         #[name(picture)]
                         set_child = &gtk::Picture {
-                            set_can_shrink: false,
+                            set_can_shrink: true,
+                            set_width_request: 170,
+                            set_height_request: 170,
                         }
                     }
                 }

--- a/src/app/components/library.rs
+++ b/src/app/components/library.rs
@@ -7,9 +7,11 @@ use fotema_core::{VisualId, YearMonth};
 use relm4::*;
 use relm4::adw;
 use std::str::FromStr;
+use std::sync::Arc;
 use strum::EnumString;
 use strum::IntoStaticStr;
 
+use crate::app::adaptive;
 use crate::app::SharedState;
 use crate::app::ActiveView;
 use crate::app::ViewName;
@@ -65,7 +67,7 @@ enum LibraryViewName {
 
 #[relm4::component(pub)]
 impl SimpleComponent for Library {
-    type Init = (SharedState, ActiveView);
+    type Init = (SharedState, ActiveView, Arc<adaptive::LayoutState>);
     type Input = LibraryInput;
     type Output = LibraryOutput;
 
@@ -79,7 +81,7 @@ impl SimpleComponent for Library {
     }
 
     fn init(
-        (state, active_view): Self::Init,
+        (state, active_view, layout_state): Self::Init,
         root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
@@ -91,6 +93,7 @@ impl SimpleComponent for Library {
             });
 
         state.subscribe(all_album.sender(), |_| AlbumInput::Refresh);
+        layout_state.subscribe(all_album.sender(), |layout| AlbumInput::Adapt(*layout));
 
         let months_album = MonthsAlbum::builder()
             .launch((state.clone(), active_view.clone()))


### PR DESCRIPTION
The month and year thumbnail grids are a little smaller so that two thumbnails can fit side-by-side on mobile screen.
The regular album view now dynamically resizes to be three thumbnails wide on narrow displays.