### PR TITLE
Back to bindings, but move bound state flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "fotema"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "fotema"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["David Bliss <hello@fotema.app>"]
 edition = "2021"
 publish = false

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@
 project(
   'fotema',
   'rust',
-  version: '1.7.0',
+  version: '1.8.0',
   meson_version: '>= 0.59',
   # license: 'MIT',
 )

--- a/src/app/components/albums/months_album.rs
+++ b/src/app/components/albums/months_album.rs
@@ -16,14 +16,12 @@ use relm4::gtk::prelude::FrameExt;
 use relm4::gtk::prelude::WidgetExt;
 use relm4::typed_view::grid::{RelmGridItem, TypedGridView};
 use relm4::*;
+use relm4::binding::*;
 
 use fotema_core::Year;
 use fotema_core::YearMonth;
 use std::path;
 use std::sync::Arc;
-use std::rc::Rc;
-use std::cell::RefCell;
-use std::collections::HashSet;
 
 use crate::adaptive;
 use crate::app::SharedState;
@@ -40,20 +38,23 @@ const WIDE_EDGE_LENGTH: i32 = 200;
 struct PhotoGridItem {
     picture: Arc<fotema_core::visual::Visual>,
 
-    // Set of all thumbnails to allow for easy resizing on layout change.
-    thumbnails: Rc<RefCell<HashSet<gtk::Picture>>>,
+    // Length of thumbnail edge to allow for resizing when layout changes.
+    edge_length: I32Binding,
 }
 
 struct Widgets {
     picture: gtk::Picture,
     label: gtk::Label,
+
+    // If the gtk::Picture has been bound to edge_length.
+    is_bound: bool,
 }
 #[derive(Debug)]
 pub enum MonthsAlbumInput {
     Activate,
 
     /// A month has been selected in the grid view
-    Selected(u32), // WARN this is an index into a Vec, not a month
+    MonthSelected(u32), // WARN this is an index into a Vec, not a month
 
     /// Scroll to first photo of year
     GoToYear(Year),
@@ -105,7 +106,11 @@ impl RelmGridItem for PhotoGridItem {
             }
         }
 
-        let widgets = Widgets { picture, label };
+        let widgets = Widgets {
+            picture,
+            label,
+            is_bound: false,
+        };
 
         (root, widgets)
     }
@@ -113,10 +118,14 @@ impl RelmGridItem for PhotoGridItem {
     fn bind(&mut self, widgets: &mut Self::Widgets, _root: &mut Self::Root) {
         let ym = self.picture.year_month();
 
-        // Add our picture to the set of all pictures so it can be easily resized
-        // when the window dimensions changes between wide and narrow.
-        if !self.thumbnails.borrow().contains(&widgets.picture) {
-            self.thumbnails.borrow_mut().insert(widgets.picture.clone());
+        // If we repeatedly bind, then Fotema will die with the following error:
+        // (fotema:2): GLib-GObject-CRITICAL **: 13:26:14.297: Too many GWeakRef registered
+        // GLib-GObject:ERROR:../gobject/gbinding.c:805:g_binding_constructed: assertion failed: (source != NULL)
+        // Bail out! GLib-GObject:ERROR:../gobject/gbinding.c:805:g_binding_constructed: assertion failed: (source != NULL)
+        if !widgets.is_bound {
+            widgets.picture.add_write_only_binding(&self.edge_length, "width-request");
+            widgets.picture.add_write_only_binding(&self.edge_length, "height-request");
+            widgets.is_bound = true;
         }
 
         widgets
@@ -157,55 +166,48 @@ pub struct MonthsAlbum {
     state: SharedState,
     active_view: ActiveView,
     photo_grid: TypedGridView<PhotoGridItem, gtk::SingleSelection>,
-    layout: adaptive::Layout,
-    thumbnails: Rc<RefCell<HashSet<gtk::Picture>>>,
+    edge_length: I32Binding,
 }
 
-pub struct MonthsAlbumWidgets {
-    // All pictures referenced by grid view.
-    thumbnails: Rc<RefCell<HashSet<gtk::Picture>>>,
-}
-
-//#[relm4::component(pub)]
+#[relm4::component(pub)]
 impl SimpleComponent for MonthsAlbum {
     type Init = (SharedState, ActiveView);
     type Input = MonthsAlbumInput;
     type Output = MonthsAlbumOutput;
-    type Root = gtk::ScrolledWindow;
-    type Widgets = MonthsAlbumWidgets;
 
-    fn init_root() -> Self::Root {
-        gtk::ScrolledWindow::builder()
-            .vexpand(true)
-            .build()
+    view! {
+        gtk::ScrolledWindow {
+            set_vexpand: true,
+
+            #[local_ref]
+            photo_grid_view -> gtk::GridView {
+                set_orientation: gtk::Orientation::Vertical,
+                set_single_click_activate: true,
+
+                connect_activate[sender] => move |_, idx| {
+                    sender.input(MonthsAlbumInput::MonthSelected(idx))
+                },
+            },
+        }
     }
 
     fn init(
         (state, active_view): Self::Init,
-        root: Self::Root,
+        _root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let photo_grid = TypedGridView::new();
-
-        let grid_view = &photo_grid.view;
-        grid_view.set_orientation(gtk::Orientation::Vertical);
-        grid_view.set_single_click_activate(true);
-        grid_view.connect_activate(move |_, idx| sender.input(MonthsAlbumInput::Selected(idx)));
 
         let model = MonthsAlbum {
             state,
             active_view,
             photo_grid,
-            layout: adaptive::Layout::Narrow,
-            thumbnails: Rc::new(RefCell::new(HashSet::new())),
+            edge_length: I32Binding::new(NARROW_EDGE_LENGTH),
         };
 
-        let widgets = MonthsAlbumWidgets {
-            thumbnails: model.thumbnails.clone(),
-        };
+        let photo_grid_view = &model.photo_grid.view;
 
-        root.set_child(Some(&model.photo_grid.view));
-
+        let widgets = view_output!();
         ComponentParts { model, widgets }
     }
 
@@ -224,7 +226,7 @@ impl SimpleComponent for MonthsAlbum {
                     self.photo_grid.clear();
                 }
             }
-            MonthsAlbumInput::Selected(index) => {
+            MonthsAlbumInput::MonthSelected(index) => {
                 if let Some(item) = self.photo_grid.get(index) {
                     let ym = item.borrow().picture.year_month();
                     event!(Level::DEBUG, "index {} has year_month {}", index, ym);
@@ -243,31 +245,14 @@ impl SimpleComponent for MonthsAlbum {
                     self.photo_grid.view.scroll_to(index, flags, None);
                 }
             }
-            MonthsAlbumInput::Adapt(layout) => {
-                self.layout = layout;
+            MonthsAlbumInput::Adapt(adaptive::Layout::Narrow) => {
+                self.edge_length.set_value(NARROW_EDGE_LENGTH);
+            },
+            MonthsAlbumInput::Adapt(adaptive::Layout::Wide) => {
+                self.edge_length.set_value(WIDE_EDGE_LENGTH);
             },
         }
     }
-
-    fn update_view(&self, widgets: &mut Self::Widgets, _sender: ComponentSender<Self>) {
-        match self.layout {
-            // Update thumbnail size depending on adaptive layout type
-            adaptive::Layout::Narrow => {
-                let pics = widgets.thumbnails.borrow_mut();
-                for pic in pics.iter() {
-                    pic.set_width_request(NARROW_EDGE_LENGTH);
-                    pic.set_height_request(NARROW_EDGE_LENGTH);
-                }
-            },
-            adaptive::Layout::Wide => {
-                let pics = widgets.thumbnails.borrow_mut();
-                for pic in pics.iter() {
-                    pic.set_width_request(WIDE_EDGE_LENGTH);
-                    pic.set_height_request(WIDE_EDGE_LENGTH);
-                }
-             },
-         }
-     }
 }
 
 impl MonthsAlbum {
@@ -279,12 +264,11 @@ impl MonthsAlbum {
                 .dedup_by(|x, y| x.year_month() == y.year_month())
                 .map(|picture| PhotoGridItem {
                     picture: picture.clone(),
-                    thumbnails: self.thumbnails.clone(),
+                    edge_length: self.edge_length.clone(),
                 })
                 .collect::<Vec<PhotoGridItem>>()
         };
 
-        self.thumbnails.borrow_mut().clear();
         self.photo_grid.clear();
         self.photo_grid.extend_from_iter(all_pictures);
 

--- a/src/app/components/albums/years_album.rs
+++ b/src/app/components/albums/years_album.rs
@@ -18,12 +18,10 @@ use relm4::gtk::prelude::FrameExt;
 use relm4::gtk::prelude::WidgetExt;
 use relm4::typed_view::grid::{RelmGridItem, TypedGridView};
 use relm4::*;
+use relm4::binding::*;
 
 use std::path;
 use std::sync::Arc;
-use std::rc::Rc;
-use std::cell::RefCell;
-use std::collections::HashSet;
 
 use crate::adaptive;
 use crate::app::SharedState;
@@ -37,15 +35,15 @@ const WIDE_EDGE_LENGTH: i32 = 200;
 struct PhotoGridItem {
     picture: Arc<fotema_core::visual::Visual>,
 
-    // Set of all thumbnails to allow for easy resizing on layout change.
-    thumbnails: Rc<RefCell<HashSet<gtk::Picture>>>,
+    // Length of thumbnail edge to allow for resizing when layout changes.
+    edge_length: I32Binding,
 }
 #[derive(Debug)]
 pub enum YearsAlbumInput {
     Activate,
 
     /// User has selected year in grid view
-    Selected(u32), // WARN this is an index into an Vec, not a year.
+    YearSelected(u32), // WARN this is an index into an Vec, not a year.
 
     // Reload photos from database
     Refresh,
@@ -62,6 +60,9 @@ pub enum YearsAlbumOutput {
 struct Widgets {
     picture: gtk::Picture,
     label: gtk::Label,
+
+    // If the gtk::Picture has been bound to edge_length.
+     is_bound: bool,
 }
 
 impl RelmGridItem for PhotoGridItem {
@@ -99,7 +100,11 @@ impl RelmGridItem for PhotoGridItem {
             }
         }
 
-        let widgets = Widgets { picture, label };
+        let widgets = Widgets {
+            picture,
+            label,
+            is_bound: false,
+        };
 
         (root, widgets)
     }
@@ -109,10 +114,14 @@ impl RelmGridItem for PhotoGridItem {
             .label
             .set_text(format!("{}", self.picture.year()).as_str());
 
-        // Add our picture to the set of all pictures so it can be easily resized
-        // when the window dimensions changes between wide and narrow.
-        if !self.thumbnails.borrow().contains(&widgets.picture) {
-            self.thumbnails.borrow_mut().insert(widgets.picture.clone());
+        // If we repeatedly bind, then Fotema will die with the following error:
+        // (fotema:2): GLib-GObject-CRITICAL **: 13:26:14.297: Too many GWeakRef registered
+        // GLib-GObject:ERROR:../gobject/gbinding.c:805:g_binding_constructed: assertion failed: (source != NULL)
+        // Bail out! GLib-GObject:ERROR:../gobject/gbinding.c:805:g_binding_constructed: assertion failed: (source != NULL)
+        if !widgets.is_bound {
+            widgets.picture.add_write_only_binding(&self.edge_length, "width-request");
+            widgets.picture.add_write_only_binding(&self.edge_length, "height-request");
+            widgets.is_bound = true;
         }
 
         if self.picture.thumbnail_path.as_ref().is_some_and(|x| x.exists()) {
@@ -146,55 +155,51 @@ pub struct YearsAlbum {
     state: SharedState,
     active_view: ActiveView,
     photo_grid: TypedGridView<PhotoGridItem, gtk::NoSelection>,
-    layout: adaptive::Layout,
-    thumbnails: Rc<RefCell<HashSet<gtk::Picture>>>,
+    edge_length: I32Binding,
 }
 
-pub struct YearsAlbumWidgets {
-    // All pictures referenced by grid view.
-    thumbnails: Rc<RefCell<HashSet<gtk::Picture>>>,
-}
-
-//#[relm4::component(pub)]
+#[relm4::component(pub)]
 impl SimpleComponent for YearsAlbum {
     type Init = (SharedState, ActiveView);
     type Input = YearsAlbumInput;
     type Output = YearsAlbumOutput;
-    type Root = gtk::ScrolledWindow;
-    type Widgets = YearsAlbumWidgets;
 
-    fn init_root() -> Self::Root {
-        gtk::ScrolledWindow::builder()
-            .vexpand(true)
-            .build()
+    view! {
+        gtk::ScrolledWindow {
+            //set_propagate_natural_height: true,
+            //set_has_frame: true,
+            set_vexpand: true,
+
+            #[local_ref]
+            photo_grid_view -> gtk::GridView {
+                set_orientation: gtk::Orientation::Vertical,
+                set_single_click_activate: true,
+                //set_max_columns: 3,
+
+                connect_activate[sender] => move |_, idx| {
+                    sender.input(YearsAlbumInput::YearSelected(idx))
+                },
+            },
+        }
     }
 
     fn init(
         (state, active_view): Self::Init,
-        root: Self::Root,
+        _root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let photo_grid = TypedGridView::new();
-
-        let grid_view = &photo_grid.view;
-        grid_view.set_orientation(gtk::Orientation::Vertical);
-        grid_view.set_single_click_activate(true);
-        grid_view.connect_activate(move |_, idx| sender.input(YearsAlbumInput::Selected(idx)));
 
         let model = YearsAlbum {
             state,
             active_view,
             photo_grid,
-            layout: adaptive::Layout::Narrow,
-            thumbnails: Rc::new(RefCell::new(HashSet::new())),
+            edge_length: I32Binding::new(NARROW_EDGE_LENGTH),
         };
 
-        let widgets = YearsAlbumWidgets {
-            thumbnails: model.thumbnails.clone(),
-        };
+        let photo_grid_view = &model.photo_grid.view;
 
-        root.set_child(Some(&model.photo_grid.view));
-
+        let widgets = view_output!();
         ComponentParts { model, widgets }
     }
 
@@ -213,37 +218,20 @@ impl SimpleComponent for YearsAlbum {
                     self.photo_grid.clear();
                 }
             }
-            YearsAlbumInput::Selected(index) => {
+            YearsAlbumInput::YearSelected(index) => {
                 if let Some(item) = self.photo_grid.get(index) {
                     let date = item.borrow().picture.year_month();
                     let _ = sender.output(YearsAlbumOutput::YearSelected(date.year));
                 }
             },
-            YearsAlbumInput::Adapt(layout) => {
-                self.layout = layout;
+            YearsAlbumInput::Adapt(adaptive::Layout::Narrow) => {
+                self.edge_length.set_value(NARROW_EDGE_LENGTH);
+            },
+            YearsAlbumInput::Adapt(adaptive::Layout::Wide) => {
+                self.edge_length.set_value(WIDE_EDGE_LENGTH);
             },
         }
     }
-
-    fn update_view(&self, widgets: &mut Self::Widgets, _sender: ComponentSender<Self>) {
-        match self.layout {
-            // Update thumbnail size depending on adaptive layout type
-            adaptive::Layout::Narrow => {
-                let pics = widgets.thumbnails.borrow_mut();
-                for pic in pics.iter() {
-                    pic.set_width_request(NARROW_EDGE_LENGTH);
-                    pic.set_height_request(NARROW_EDGE_LENGTH);
-                }
-            },
-            adaptive::Layout::Wide => {
-                let pics = widgets.thumbnails.borrow_mut();
-                for pic in pics.iter() {
-                    pic.set_width_request(WIDE_EDGE_LENGTH);
-                    pic.set_height_request(WIDE_EDGE_LENGTH);
-                }
-             },
-         }
-     }
 }
 
 impl YearsAlbum {
@@ -255,12 +243,11 @@ impl YearsAlbum {
                 .dedup_by(|x, y| x.year() == y.year())
                 .map(|picture| PhotoGridItem {
                     picture: picture.clone(),
-                    thumbnails: self.thumbnails.clone(),
+                    edge_length: self.edge_length.clone(),
                 })
                 .collect::<Vec<PhotoGridItem>>()
         };
 
-        self.thumbnails.borrow_mut().clear();
         self.photo_grid.clear();
         self.photo_grid.extend_from_iter(all_pictures);
 


### PR DESCRIPTION
In my last attempt, the `is_bound` flag was stored on the RelmGridItem. This was a mistake, as the binding of the thumbnail to the edge_length belongs on the RelmGridItem widget.

Moving the state fixes the problem of thumbnails resizing incorrectly.