### PR TITLE
Fix hamburger menu not showing in mobile view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -210,9 +210,6 @@ impl SimpleComponent for App {
                 glib::Propagation::Stop
             },
 
-            // Notifies initial width of window so we can set correct adaptive layout for widgets
-            connect_is_active_notify => AppMsg::Activate(root.width()),
-
             add_css_class?: if PROFILE == "Devel" {
                     Some("devel")
                 } else {
@@ -591,6 +588,9 @@ impl SimpleComponent for App {
         actions.register_for_widget(&widgets.main_window);
 
         widgets.load_window_size();
+
+        // Get startup window size and propagate so all components have correct narrow/wide layout.
+        sender.input(AppMsg::Activate(widgets.main_window.default_width()));
 
         model.spinner.set_visible(true);
         model.spinner.start();


### PR DESCRIPTION
The "is active" signal was being used to determine the initial width of the window so all components could be configured with the correct wide/narrow layout. However, this signal triggered all the time, and processing the message for it would cause the hamburger menu to collapse when in the mobile view.

Instead, just send a single message at startup to configure the width.