### PR TITLE
Always Gnable glycin sandbox to prevent errors when running through GNOME Builder :-/

### DIFF
--- a/core/src/machine_learning/face_extractor.rs
+++ b/core/src/machine_learning/face_extractor.rs
@@ -404,7 +404,9 @@ impl FaceExtractor {
     async fn open_image(source_path: &Path) -> Result<DynamicImage> {
         let file = gio::File::for_path(source_path);
 
-        let image = glycin::Loader::new(file).load().await?;
+        let mut loader = glycin::Loader::new(file);
+        loader.sandbox_selector(glycin::SandboxSelector::FlatpakSpawn);
+        let image = loader.load().await?;
 
         let frame = image.next_frame().await?;
 

--- a/core/src/photo/thumbnail.rs
+++ b/core/src/photo/thumbnail.rs
@@ -124,6 +124,7 @@ impl Thumbnailer {
         // here and then not have to rotate the thumbnails in the album views.
         // However, will have to re-generate existing non-rotated thumbnails.
         let mut loader = glycin::Loader::new(file);
+        loader.sandbox_selector(glycin::SandboxSelector::FlatpakSpawn);
         loader.apply_transformations(false);
 
         let image = loader.load().await?;

--- a/src/app/components/viewer/view_one.rs
+++ b/src/app/components/viewer/view_one.rs
@@ -351,6 +351,7 @@ impl SimpleAsyncComponent for ViewOne {
                     let file = gio::File::for_path(visual_path);
 
                     let mut loader = glycin::Loader::new(file);
+                    loader.sandbox_selector(glycin::SandboxSelector::FlatpakSpawn);
                     loader.apply_transformations(false);
 
                     let image = loader.load().await;


### PR DESCRIPTION
Glycin 2.0.0.beta disables the sandbox when it detects it is running a development build. However, for Fotema this produces errors when loading images when run through GNOME Builder, breaking thumbnail generation, face detection, and image viewing.

As Fotema targets flatpak for packaging I have chosen to always enable the "flatpak spawn" sandbox.
