### PR TITLE
User can change chronological album sort order

### DIFF
--- a/data/app.fotema.Fotema.gschema.xml.in
+++ b/data/app.fotema.Fotema.gschema.xml.in
@@ -22,5 +22,9 @@
       <default>'Off'</default>
       <summary>Enable face detection and person recognition. 'Off', 'Mobile', 'Desktop'.</summary>
     </key>
+    <key name="album-sort" type="s">
+      <default>'Ascending'</default>
+      <summary>Sort direction for albums. 'Ascending', 'Descending'.</summary>
+    </key>
   </schema>
 </schemalist>

--- a/i18n/en-US/fotema.ftl
+++ b/i18n/en-US/fotema.ftl
@@ -224,18 +224,29 @@ people-not-this-person = Not { $name }
 prefs-title = Preferences
 
 # Title of section of preferences for views
-prefs-views-section = Views
-  .description = Show or hide sidebar views
+prefs-ui-section = UI
+  .description = Tweak the user interface.
 
 # Selfies page enabled or disabled.
 # Attributes:
 #   .subtitle - Description of toggle button action action.
-prefs-views-selfies = Selfies
-  .subtitle = Shows a separate view for selfies taken on iOS devices. Restart {-app-name} to apply.
+prefs-ui-selfies = Selfies
+  .subtitle = Shows a separate album for selfies taken on iOS devices. Restart {-app-name} to apply.
 
-# Set face detection mode. Off, lightweight mobile model, or heavyweight
-# desktop model
-prefs-views-faces = Face Detection
+# Album sort drop-down menu
+prefs-ui-chronological-album-sort = Sort Order
+  .subtitle = Chronological sort order for albums.
+  .ascending = Ascending
+  .descending = Descending
+
+# Preferences related to machine learning, such as face detection.
+# Machine learning is CPU intensive so capabilities can be turned on or off by
+# the user
+prefs-machine-learning-section = Machine Learning
+  .description = Configure machine learning features.
+
+# Enable or disable face detection
+prefs-machine-learning-face-detection = Face Detection
   .subtitle = Enable face detection when Fotema launches. This is a time consuming process.
 
 ## Progress bar for background tasks

--- a/src/app.rs
+++ b/src/app.rs
@@ -621,6 +621,7 @@ impl SimpleComponent for App {
 
         state.subscribe(person_album.sender(), |_| PersonAlbumInput::Refresh);
         adaptive_layout.subscribe(person_album.sender(), |layout| PersonAlbumInput::Adapt(*layout));
+        settings_state.subscribe(person_album.sender(), |settings| PersonAlbumInput::Sort(settings.album_sort));
 
         let places_page = PlacesAlbum::builder()
             .launch((state.clone(), active_view.clone()))

--- a/src/app.rs
+++ b/src/app.rs
@@ -51,6 +51,7 @@ use self::components::{
     albums:: {
         album::{Album, AlbumInput, AlbumOutput},
         album_filter::AlbumFilter,
+        album_sort::AlbumSort,
         folders_album::{FoldersAlbum, FoldersAlbumInput, FoldersAlbumOutput},
         people_album::{PeopleAlbum, PeopleAlbumInput, PeopleAlbumOutput},
         person_album::{PersonAlbum, PersonAlbumInput, PersonAlbumOutput},
@@ -110,6 +111,10 @@ pub struct Settings {
 
     /// Enable or disable face detection.
     pub face_detection_mode: FaceDetectionMode,
+
+    /// Sorting for albums.
+    /// NOTE: doesn't include folder's album.
+    pub album_sort: AlbumSort,
 }
 
 /// Active settings
@@ -544,6 +549,8 @@ impl SimpleComponent for App {
                 LibraryOutput::View(id) => AppMsg::View(id, AlbumFilter::All),
             });
 
+        settings_state.subscribe(library.sender(), |settings| LibraryInput::Sort(settings.album_sort));
+
         let transcoder = video::Transcoder::new(&cache_dir);
 
         let video_transcode = VideoTranscode::builder()
@@ -566,6 +573,7 @@ impl SimpleComponent for App {
 
         state.subscribe(selfies_page.sender(), |_| AlbumInput::Refresh);
         adaptive_layout.subscribe(selfies_page.sender(), |layout| AlbumInput::Adapt(*layout));
+        settings_state.subscribe(selfies_page.sender(), |settings| AlbumInput::Sort(settings.album_sort));
 
         let show_selfies = AppWidgets::show_selfies();
 
@@ -578,6 +586,7 @@ impl SimpleComponent for App {
 
         state.subscribe(motion_page.sender(), |_| AlbumInput::Refresh);
         adaptive_layout.subscribe(motion_page.sender(), |layout| AlbumInput::Adapt(*layout));
+        settings_state.subscribe(motion_page.sender(), |settings| AlbumInput::Sort(settings.album_sort));
 
         let videos_page = Album::builder()
             .launch((state.clone(), active_view.clone(), ViewName::Videos, AlbumFilter::Videos))
@@ -588,6 +597,7 @@ impl SimpleComponent for App {
 
         state.subscribe(videos_page.sender(), |_| AlbumInput::Refresh);
         adaptive_layout.subscribe(videos_page.sender(), |layout| AlbumInput::Adapt(*layout));
+        settings_state.subscribe(videos_page.sender(), |settings| AlbumInput::Sort(settings.album_sort));
 
         let people_page = PeopleAlbum::builder()
             .launch((people_repo.clone(), active_view.clone(), settings_state.clone()))
@@ -643,6 +653,7 @@ impl SimpleComponent for App {
 
         state.subscribe(folder_album.sender(), |_| AlbumInput::Refresh);
         adaptive_layout.subscribe(folder_album.sender(), |layout| AlbumInput::Adapt(*layout));
+        settings_state.subscribe(folder_album.sender(), |settings| AlbumInput::Sort(settings.album_sort));
 
         let about_dialog = AboutDialog::builder().launch(root.clone()).detach();
 
@@ -923,6 +934,8 @@ impl App {
             show_selfies: gio_settings.boolean("show-selfies"),
             face_detection_mode: FaceDetectionMode::from_str(&gio_settings.string("face-detection-mode"))
                 .unwrap_or(FaceDetectionMode::Off),
+            album_sort: AlbumSort::from_str(&gio_settings.string("album-sort"))
+                .unwrap_or(AlbumSort::Ascending),
         })
     }
 
@@ -931,6 +944,7 @@ impl App {
         let gio_settings = gio::Settings::new(APP_ID);
         gio_settings.set_boolean("show-selfies", settings.show_selfies)?;
         gio_settings.set_string("face-detection-mode", settings.face_detection_mode.as_ref())?;
+        gio_settings.set_string("album-sort", settings.album_sort.as_ref())?;
         Ok(())
     }
 }

--- a/src/app/components/albums/album.rs
+++ b/src/app/components/albums/album.rs
@@ -53,6 +53,9 @@ pub enum AlbumInput {
     // Show no photos
     Filter(AlbumFilter),
 
+    // Sort
+    Sort(AlbumSort),
+
     // Adapt to layout
     Adapt(adaptive::Layout),
 
@@ -303,6 +306,13 @@ impl SimpleComponent for Album {
             AlbumInput::Filter(filter) => {
                 self.filter = filter;
                 self.update_filter();
+            }
+            AlbumInput::Sort(sort) => {
+                if self.sort != sort {
+                    info!("Sort order is now {:?}", sort);
+                    self.sort = sort;
+                    sender.input(AlbumInput::Refresh);
+                }
             }
             AlbumInput::Selected(index) => {
                 // Albums are filters so must use get_visible(...) over get(...), otherwise

--- a/src/app/components/albums/album.rs
+++ b/src/app/components/albums/album.rs
@@ -276,7 +276,7 @@ impl SimpleComponent for Album {
             view_name,
             photo_grid,
             filter,
-            sort: AlbumSort::Ascending,
+            sort: AlbumSort::default(),
             edge_length: I32Binding::new(NARROW_EDGE_LENGTH),
         };
 

--- a/src/app/components/albums/album_sort.rs
+++ b/src/app/components/albums/album_sort.rs
@@ -27,35 +27,6 @@ impl AlbumSort {
         }
     }
 
-    pub fn scroll_to_start<T: RelmGridItem>(&self, grid: &mut TypedGridView<T, gtk::SingleSelection>) {
-        if grid.is_empty() {
-            return;
-        }
-
-        // We must scroll to a valid index... but we can't get the index of the
-        // last item if filters are enabled. So as a workaround disable filters,
-        // scroll to end, and then enable filters.
-
-        for i in 0..(grid.filters_len()) {
-            grid.set_filter_status(i, false);
-        }
-
-        let index = match self {
-            AlbumSort::Ascending => 0,
-            AlbumSort::Descending => grid.len() - 1,
-        };
-
-        grid.view.scroll_to(
-            index,
-            gtk::ListScrollFlags::SELECT,
-            None,
-        );
-
-        for i in 0..(grid.filters_len()) {
-            grid.set_filter_status(i, true);
-        }
-    }
-
     pub fn scroll_to_end<T: RelmGridItem>(&self, grid: &mut TypedGridView<T, gtk::SingleSelection>) {
         if grid.is_empty() {
             return;

--- a/src/app/components/albums/album_sort.rs
+++ b/src/app/components/albums/album_sort.rs
@@ -4,11 +4,16 @@
 
 use relm4::typed_view::grid::{RelmGridItem, TypedGridView};
 use relm4::gtk;
+use strum::EnumString;
+use strum::AsRefStr;
+use strum::FromRepr;
 
 // Sort album
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, EnumString, AsRefStr, FromRepr)]
+#[repr(u32)]
 pub enum AlbumSort {
     // Sort dimension from smallest to largest
+    #[default]
     Ascending,
 
     // Sort dimension from largest to smallest

--- a/src/app/components/albums/album_sort.rs
+++ b/src/app/components/albums/album_sort.rs
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2024 David Bliss
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use relm4::typed_view::grid::{RelmGridItem, TypedGridView};
+use relm4::gtk;
+
+// Sort album
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlbumSort {
+    // Sort dimension from smallest to largest
+    Ascending,
+
+    // Sort dimension from largest to smallest
+    Descending,
+}
+
+impl AlbumSort {
+    pub fn sort<T>(&self, data: &mut [T]) {
+        if *self == AlbumSort::Descending {
+            data.reverse();
+        }
+    }
+
+    pub fn scroll_to_start<T: RelmGridItem>(&self, grid: &mut TypedGridView<T, gtk::SingleSelection>) {
+        if grid.is_empty() {
+            return;
+        }
+
+        // We must scroll to a valid index... but we can't get the index of the
+        // last item if filters are enabled. So as a workaround disable filters,
+        // scroll to end, and then enable filters.
+
+        for i in 0..(grid.filters_len()) {
+            grid.set_filter_status(i, false);
+        }
+
+        let index = match self {
+            AlbumSort::Ascending => 0,
+            AlbumSort::Descending => grid.len() - 1,
+        };
+
+        grid.view.scroll_to(
+            index,
+            gtk::ListScrollFlags::SELECT,
+            None,
+        );
+
+        for i in 0..(grid.filters_len()) {
+            grid.set_filter_status(i, true);
+        }
+    }
+
+    pub fn scroll_to_end<T: RelmGridItem>(&self, grid: &mut TypedGridView<T, gtk::SingleSelection>) {
+        if grid.is_empty() {
+            return;
+        }
+
+        // We must scroll to a valid index... but we can't get the index of the
+        // last item if filters are enabled. So as a workaround disable filters,
+        // scroll to end, and then enable filters.
+
+        for i in 0..(grid.filters_len()) {
+            grid.set_filter_status(i, false);
+        }
+
+        let index = match self {
+            AlbumSort::Ascending => grid.len() - 1,
+            AlbumSort::Descending => 0,
+        };
+
+        grid.view.scroll_to(
+            index,
+            gtk::ListScrollFlags::SELECT,
+            None,
+        );
+
+        for i in 0..(grid.filters_len()) {
+            grid.set_filter_status(i, true);
+        }
+    }
+}

--- a/src/app/components/albums/mod.rs
+++ b/src/app/components/albums/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod album;
 pub mod album_filter;
+pub mod album_sort;
 pub mod folders_album;
 pub mod months_album;
 pub mod people_album;

--- a/src/app/components/albums/person_album.rs
+++ b/src/app/components/albums/person_album.rs
@@ -20,6 +20,7 @@ use crate::app::ViewName;
 use crate::app::components::albums:: {
     album::{Album, AlbumInput, AlbumOutput},
     album_filter::AlbumFilter,
+    album_sort::AlbumSort,
 };
 
 use fotema_core::people;
@@ -71,6 +72,8 @@ pub enum PersonAlbumInput {
 
     /// Actually delete person.
     Delete,
+
+    Sort(AlbumSort),
 }
 
 #[derive(Debug)]
@@ -207,6 +210,11 @@ impl SimpleComponent for PersonAlbum {
             PersonAlbumInput::Refresh => {
                 self.album.sender().emit(AlbumInput::Refresh);
             }
+            PersonAlbumInput::Sort(sort) => {
+                self.album.sender().emit(AlbumInput::Sort(sort));
+                self.album.sender().emit(AlbumInput::ScrollToTop)
+                //self.album.sender().emit(AlbumInput::ScrollOffset(0.0));
+            },
             PersonAlbumInput::View(person) => {
                 info!("Viewing album for person: {}", person.person_id);
 
@@ -222,7 +230,7 @@ impl SimpleComponent for PersonAlbum {
                 info!("Person {} has {} items to view.", person.person_id, self.picture_ids.len());
                 self.album.sender().emit(AlbumInput::Activate);
                 self.album.sender().emit(AlbumInput::Filter(AlbumFilter::Any(self.picture_ids.clone())));
-                self.album.sender().emit(AlbumInput::GoToFirst);
+                self.album.sender().emit(AlbumInput::ScrollToTop);
 
                 self.title.set_label(&person.name);
                 self.person = Some(person);

--- a/src/app/components/library.rs
+++ b/src/app/components/library.rs
@@ -19,6 +19,7 @@ use crate::fl;
 
 use super::albums::album::{Album, AlbumInput, AlbumOutput};
 use super::albums::album_filter::AlbumFilter;
+use super::albums::album_sort::AlbumSort;
 use super::albums::months_album::{MonthsAlbum, MonthsAlbumInput, MonthsAlbumOutput};
 use super::albums::years_album::{YearsAlbum, YearsAlbumInput, YearsAlbumOutput};
 
@@ -42,6 +43,8 @@ pub enum LibraryInput {
     GoToYear(i32),
 
     View(VisualId),
+
+    Sort(AlbumSort),
 }
 
 #[derive(Debug)]
@@ -162,6 +165,9 @@ impl SimpleComponent for Library {
             },
             LibraryInput::View(id) => {
                 let _ = sender.output(LibraryOutput::View(id));
+            },
+            LibraryInput::Sort(sort) => {
+                self.all_album.emit(AlbumInput::Sort(sort));
             },
         }
     }

--- a/src/app/components/library.rs
+++ b/src/app/components/library.rs
@@ -168,6 +168,7 @@ impl SimpleComponent for Library {
             },
             LibraryInput::Sort(sort) => {
                 self.all_album.emit(AlbumInput::Sort(sort));
+                self.months_album.emit(MonthsAlbumInput::Sort(sort));
             },
         }
     }

--- a/src/app/components/library.rs
+++ b/src/app/components/library.rs
@@ -169,6 +169,7 @@ impl SimpleComponent for Library {
             LibraryInput::Sort(sort) => {
                 self.all_album.emit(AlbumInput::Sort(sort));
                 self.months_album.emit(MonthsAlbumInput::Sort(sort));
+                self.years_album.emit(YearsAlbumInput::Sort(sort));
             },
         }
     }

--- a/src/app/components/preferences.rs
+++ b/src/app/components/preferences.rs
@@ -57,12 +57,12 @@ impl SimpleComponent for PreferencesDialog {
             set_title: &fl!("prefs-title"),
             add = &adw::PreferencesPage {
                 add = &adw::PreferencesGroup {
-                    set_title: &fl!("prefs-views-section"),
-                    set_description: Some(&fl!("prefs-views-section", "description")),
+                    set_title: &fl!("prefs-ui-section"),
+                    set_description: Some(&fl!("prefs-ui-section", "description")),
 
                     adw::SwitchRow {
-                        set_title: &fl!("prefs-views-selfies"),
-                        set_subtitle: &fl!("prefs-views-selfies", "subtitle"),
+                        set_title: &fl!("prefs-ui-selfies"),
+                        set_subtitle: &fl!("prefs-ui-selfies", "subtitle"),
 
                         #[watch]
                         set_active: model.settings.show_selfies,
@@ -73,9 +73,25 @@ impl SimpleComponent for PreferencesDialog {
                     },
 
                     #[local_ref]
+                    album_sort_row -> adw::ComboRow {
+                        set_title: &fl!("prefs-ui-chronological-album-sort"),
+                        set_subtitle: &fl!("prefs-ui-chronological-album-sort", "subtitle"),
+
+                        connect_selected_item_notify[sender] => move |row| {
+                            let mode = AlbumSort::from_repr(row.selected()).unwrap_or_default();
+                            let _ = sender.input_sender().send(PreferencesInput::Sort(mode));
+                        }
+                    }
+                },
+                add = &adw::PreferencesGroup {
+                    set_title: &fl!("prefs-machine-learning-section"),
+                    set_description: Some(&fl!("prefs-machine-learning-section", "description")),
+
+
+                    #[local_ref]
                     face_detection_mode_row -> adw::SwitchRow {
-                        set_title: &fl!("prefs-views-faces"),
-                        set_subtitle: &fl!("prefs-views-faces", "subtitle"),
+                        set_title: &fl!("prefs-machine-learning-face-detection"),
+                        set_subtitle: &fl!("prefs-machine-learning-face-detection", "subtitle"),
 
                         #[watch]
                         set_active: model.is_face_detection_active(),
@@ -89,17 +105,6 @@ impl SimpleComponent for PreferencesDialog {
                             let _ = sender.input_sender().send(PreferencesInput::UpdateFaceDetectionMode(mode));
                         },
                     },
-
-                    #[local_ref]
-                    album_sort_row -> adw::ComboRow {
-                        set_title: "Album sort",
-                        //set_subtitle: &fl!("prefs-views-faces", "subtitle"),
-
-                        connect_selected_item_notify[sender] => move |row| {
-                            let mode = AlbumSort::from_repr(row.selected()).unwrap_or_default();
-                            let _ = sender.input_sender().send(PreferencesInput::Sort(mode));
-                        }
-                    }
                 },
             }
         }
@@ -120,8 +125,8 @@ impl SimpleComponent for PreferencesDialog {
 
         let album_sort_row = adw::ComboRow::new();
         let list = gtk::StringList::new(&[
-            "Ascending",
-            "Descending",
+            &fl!("prefs-ui-chronological-album-sort", "ascending"),
+            &fl!("prefs-ui-chronological-album-sort", "descending"),
         ]);
         album_sort_row.set_model(Some(&list));
 


### PR DESCRIPTION
The user can set a global option to change the sort order of all chronological albums. Note that non-chronological albums can't currently have their sort order changed and will continue to be sorted alphabetically.

Fixes #144 