### PR TITLE
Integrate video transcode into regular background task manager

### DIFF
--- a/i18n/en-US/fotema.ftl
+++ b/i18n/en-US/fotema.ftl
@@ -315,6 +315,9 @@ banner-detect-faces-photos = Detecting faces in photos. This will take a while.
 # Recognize faces as people
 banner-recognize-faces-photos = Recognizing people in photos. This will take a while.
 
+# Transcoding videos to a compatible format
+banner-convert-videos = Converting videos.
+
 ## Primary menu
 
 # The "hamburger" menu on the main app navigation sidebar.

--- a/src/app/background/photo_detect_faces.rs
+++ b/src/app/background/photo_detect_faces.rs
@@ -36,7 +36,7 @@ pub enum PhotoDetectFacesOutput {
     Started,
 
     // Face detection has completed
-    Completed(usize),
+    Completed,
 
 }
 
@@ -83,7 +83,7 @@ impl PhotoDetectFaces {
         // Short-circuit before sending progress messages to stop
         // banner from appearing and disappearing.
         if count == 0 {
-            let _ = sender.output(PhotoDetectFacesOutput::Completed(count));
+            let _ = sender.output(PhotoDetectFacesOutput::Completed);
             return Ok(());
         }
 
@@ -122,7 +122,7 @@ impl PhotoDetectFaces {
 
         self.progress_monitor.emit(ProgressMonitorInput::Complete);
 
-        let _ = sender.output(PhotoDetectFacesOutput::Completed(count));
+        let _ = sender.output(PhotoDetectFacesOutput::Completed);
 
         Ok(())
     }

--- a/src/app/background/photo_recognize_faces.rs
+++ b/src/app/background/photo_recognize_faces.rs
@@ -34,7 +34,7 @@ pub enum PhotoRecognizeFacesOutput {
     Started,
 
     // Face recognition has completed
-    Completed(usize),
+    Completed,
 
 }
 
@@ -64,7 +64,7 @@ impl PhotoRecognizeFaces {
         // Short-circuit before sending progress messages to stop
         // banner from appearing and disappearing.
         if people.is_empty() {
-            let _ = sender.output(PhotoRecognizeFacesOutput::Completed(0));
+            let _ = sender.output(PhotoRecognizeFacesOutput::Completed);
             return Ok(());
         }
 
@@ -76,7 +76,7 @@ impl PhotoRecognizeFaces {
             .collect();
 
         if unprocessed.is_empty() {
-            let _ = sender.output(PhotoRecognizeFacesOutput::Completed(0));
+            let _ = sender.output(PhotoRecognizeFacesOutput::Completed);
             return Ok(());
         }
 
@@ -114,7 +114,7 @@ impl PhotoRecognizeFaces {
 
         self.progress_monitor.emit(ProgressMonitorInput::Complete);
 
-        let _ = sender.output(PhotoRecognizeFacesOutput::Completed(0)); // FIXME zero
+        let _ = sender.output(PhotoRecognizeFacesOutput::Completed);
 
         Ok(())
     }

--- a/src/app/background/video_transcode.rs
+++ b/src/app/background/video_transcode.rs
@@ -26,7 +26,7 @@ use crate::app::SharedState;
 #[derive(Debug)]
 pub enum VideoTranscodeInput {
     /// Transcode all videos
-    All,
+    Start,
 }
 
 #[derive(Debug)]
@@ -112,7 +112,7 @@ impl Worker for VideoTranscode {
 
     fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>) {
         match msg {
-            VideoTranscodeInput::All => {
+            VideoTranscodeInput::Start => {
                 info!("Transcoding all incompatible videos");
 
                 if let Err(e) = self.transcode_all(&sender) {


### PR DESCRIPTION
Fixes #155.

Video transcode is now managed by 'bootstrap.rs', which means it is handled like any other background task. This means video transcode no longer happens in parallel with other expensive tasks, removes the separate video transcode progress bar, and adds a banner for when when the task is running. This is also a pre-requisite for allowing users to stop background tasks and for supporting a user chosen library directory.