### PR TITLE
main: Set app-id

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ fn main() {
 
     let app = main_application();
     app.set_resource_base_path(Some("/app/fotema/Fotema/"));
+    app.set_application_id(Some(APP_ID));
 
     let mut actions = RelmActionGroup::<AppActionGroup>::new();
 


### PR DESCRIPTION
This ensures the correct app-id is set in toplevel windows so shells can pick up the correct icon.

See https://gitlab.gnome.org/World/Phosh/phosh/-/issues/1121#note_2234007