### PR TITLE
Taller default window size so setup screen button is not hidden

### DIFF
--- a/data/app.fotema.Fotema.gschema.xml.in
+++ b/data/app.fotema.Fotema.gschema.xml.in
@@ -6,7 +6,7 @@
       <summary>Window width</summary>
     </key>
     <key name="window-height" type="i">
-      <default>400</default>
+      <default>500</default>
       <summary>Window height</summary>
     </key>
     <key name="is-maximized" type="b">


### PR DESCRIPTION
Fix #236 