### PR TITLE
Suppress spurious events

### DIFF
--- a/core/src/machine_learning/face_recognizer.rs
+++ b/core/src/machine_learning/face_recognizer.rs
@@ -7,14 +7,14 @@ use std::io::BufWriter;
 use std::path::Path;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use opencv::core::Mat;
 use opencv::imgcodecs;
 use opencv::objdetect::{FaceRecognizerSF, FaceRecognizerSF_DisType};
 use opencv::prelude::*;
 
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT};
+use reqwest::header::{ACCEPT, HeaderMap, HeaderValue};
 
 use tracing::info;
 
@@ -32,8 +32,7 @@ impl FaceRecognizer {
     //const COSINE_SIMILAR_THRESH: f64 = 0.363;
     const L2NORM_SIMILAR_THRESH: f64 = 1.128;
 
-    const MODEL_URL: &'static str =
-        "https://github.com/blissd/fotema-opencv_zoo/raw/fotema-1.0/models/face_recognition_sface/face_recognition_sface_2021dec.onnx";
+    const MODEL_URL: &'static str = "https://github.com/blissd/fotema-opencv_zoo/raw/fotema-1.0/models/face_recognition_sface/face_recognition_sface_2021dec.onnx";
 
     pub fn build(cache_dir: &Path, people: Vec<PersonForRecognition>) -> Result<Self> {
         let model_path = {
@@ -162,9 +161,10 @@ mod tests {
     #[test]
     fn test_recognize() {
         let person_face = DetectedFace {
-
             face_id: FaceId::new(1),
-            face_path: PathBuf::from("/var/home/david/.var/app/app.fotema.Fotema.Devel/cache/app.fotema.Fotema.Devel/photo_faces/0003/3027/0_blaze_face_640_original.png"),
+            face_path: PathBuf::from(
+                "/var/home/david/.var/app/app.fotema.Fotema.Devel/cache/app.fotema.Fotema.Devel/photo_faces/0003/3027/0_blaze_face_640_original.png",
+            ),
             bounds: Rect {
                 x: 0.,
                 y: 0.,

--- a/core/src/people/repo.rs
+++ b/core/src/people/repo.rs
@@ -5,17 +5,17 @@
 use crate::photo::model::PictureId;
 
 use crate::machine_learning::face_extractor;
+use crate::people::FaceId;
+use crate::people::PersonId;
 use crate::people::model;
 use crate::people::model::PersonForRecognition;
 use crate::people::model::Rect;
-use crate::people::FaceId;
-use crate::people::PersonId;
 use crate::photo::model::Orientation;
 
 use anyhow::*;
 use rusqlite;
-use rusqlite::params;
 use rusqlite::Row;
+use rusqlite::params;
 use std::path::{Path, PathBuf};
 use std::result::Result::Ok;
 use std::sync::{Arc, Mutex};

--- a/core/src/photo/metadata.rs
+++ b/core/src/photo/metadata.rs
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use super::Metadata;
 use super::gps::GPSLocation;
 use super::model::Orientation;
-use super::Metadata;
 use anyhow::*;
 use chrono::prelude::*;
 use chrono::{DateTime, FixedOffset};

--- a/core/src/photo/repo.rs
+++ b/core/src/photo/repo.rs
@@ -4,15 +4,15 @@
 
 use crate::photo::model::{Picture, PictureId, ScannedFile};
 
+use super::Metadata;
 use super::metadata;
 use super::model::MotionPhotoVideo;
 use super::motion_photo;
-use super::Metadata;
 use crate::path_encoding;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite;
-use rusqlite::params;
 use rusqlite::Row;
+use rusqlite::params;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 

--- a/core/src/photo/thumbnail.rs
+++ b/core/src/photo/thumbnail.rs
@@ -5,11 +5,11 @@
 use crate::photo::model::PictureId;
 use anyhow::*;
 
-use image::codecs::png::PngEncoder;
 use image::DynamicImage;
 use image::ExtendedColorType;
 use image::ImageEncoder;
 use image::ImageReader;
+use image::codecs::png::PngEncoder;
 
 use fast_image_resize as fr;
 use fr::images::Image;

--- a/core/src/video/repo.rs
+++ b/core/src/video/repo.rs
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use super::metadata;
 use super::Metadata;
+use super::metadata;
 use crate::path_encoding;
 use crate::video::model::{ScannedFile, Video, VideoId};
 use anyhow::*;
 use chrono::*;
 use rusqlite;
-use rusqlite::params;
 use rusqlite::Row;
+use rusqlite::params;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 

--- a/core/src/video/transcode.rs
+++ b/core/src/video/transcode.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 use crate::video::VideoId;
 
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 #[derive(Debug, Clone)]
 pub struct Transcoder {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,13 @@ mod languages;
 use app::App;
 
 use config::{APP_ID, GETTEXT_PACKAGE, LOCALEDIR, RESOURCES_FILE};
-use gettextrs::{gettext, LocaleCategory};
+use gettextrs::{LocaleCategory, gettext};
 use gtk::prelude::ApplicationExt;
 use gtk::{gio, glib};
 use relm4::{
+    RelmApp,
     actions::{AccelsPlus, RelmAction, RelmActionGroup},
-    gtk, main_application, RelmApp,
+    gtk, main_application,
 };
 
 use tracing_subscriber::filter::EnvFilter;


### PR DESCRIPTION
This is an attempt to fix #382.

I think the problem is in `view_nav.rs` when the carousel is setup after the user clicks a picture to view. The carousel has three pages (left, current, right) and which of those pages should be the page show to the user is navigated to with a `scroll_to`. I think this is firing scroll events and causing additional scrolls (swipes) to happen which results in the wrong picture being displayed.

This PR detects when an initial page must be scrolled to and suppresses that action.