### PR TITLE
Display host path to user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "jobserver",
  "libc",
@@ -1603,9 +1603,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "glycin"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1496acef16890b0022c61298052d4ca3e1a121dd4696166c3d19242581bdb9a"
+checksum = "37cb9e103cb6b8925bf5e8a1cf8a1166797d8aaefaabd03e68cf6ad7443a1baa"
 dependencies = [
  "async-fs",
  "async-io",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "glycin-utils"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4348643b905fc981acf8ed0315ab8e315ce771cedb65034562f477cbaa4b1ee1"
+checksum = "c0816d1db00696479cda3cd6c914fb07115982b019dac96555d203c0d5b6d37a"
 dependencies = [
  "env_logger",
  "gufo-common",
@@ -4228,14 +4228,14 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
 dependencies = [
- "self_cell 1.1.0",
+ "self_cell 1.2.0",
 ]
 
 [[package]]
 name = "self_cell"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
+checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
 
 [[package]]
 name = "semver"

--- a/core/src/visual/model.rs
+++ b/core/src/visual/model.rs
@@ -51,6 +51,8 @@ pub struct Visual {
 
     pub video_path: Option<PathBuf>,
 
+    pub video_host_path: Option<PathBuf>,
+
     // Transcoded version of video_path of video_codec is not supported.
     pub video_transcoded_path: Option<PathBuf>,
 
@@ -63,6 +65,8 @@ pub struct Visual {
     pub picture_id: Option<PictureId>,
 
     pub picture_path: Option<PathBuf>,
+
+    pub picture_host_path: Option<PathBuf>,
 
     pub picture_orientation: Option<Orientation>,
 
@@ -86,7 +90,11 @@ pub struct Visual {
 
 impl Visual {
     pub fn path(&self) -> Option<&PathBuf> {
-        self.picture_path.as_ref().or(self.video_path.as_ref())
+        self.picture_host_path
+            .as_ref()
+            .or(self.video_host_path.as_ref())
+            .or(self.picture_path.as_ref())
+            .or(self.video_path.as_ref())
     }
 
     pub fn is_selfie(&self) -> bool {

--- a/data/app.fotema.Fotema.gschema.xml.in
+++ b/data/app.fotema.Fotema.gschema.xml.in
@@ -34,9 +34,5 @@
       <default>'L3Zhci9lbXB0eQ=='</default>
       <summary>Sandbox view of user selected pictures directory. Base64 encoded because paths aren't strings. Default is /var/empty</summary>
     </key>
-    <key name="pictures-base-dir-host-path-b64" type="s">
-      <default>'L3Zhci9lbXB0eQ=='</default>
-      <summary>Host-path (outside sandbox) path to pictures directory. Base64 encoded because paths aren't strings. Default is /var/empty</summary>
-    </key>
   </schema>
 </schemalist>

--- a/data/app.fotema.Fotema.gschema.xml.in
+++ b/data/app.fotema.Fotema.gschema.xml.in
@@ -32,7 +32,11 @@
     </key>
     <key name="pictures-base-dir-b64" type="s">
       <default>'L3Zhci9lbXB0eQ=='</default>
-      <summary>User-selected pictures root directory. Base64 encoded because paths aren't strings. Default is /var/empty</summary>
+      <summary>Sandbox view of user selected pictures directory. Base64 encoded because paths aren't strings. Default is /var/empty</summary>
+    </key>
+    <key name="pictures-base-dir-host-path-b64" type="s">
+      <default>'L3Zhci9lbXB0eQ=='</default>
+      <summary>Host-path (outside sandbox) path to pictures directory. Base64 encoded because paths aren't strings. Default is /var/empty</summary>
     </key>
   </schema>
 </schemalist>

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,14 +2,17 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use relm4::adw::prelude::*;
+use relm4::gtk;
+use relm4::prelude::*;
+
 use relm4::{
     Component, ComponentController, ComponentParts, ComponentSender, Controller, SimpleComponent,
     WorkerController,
     actions::{RelmAction, RelmActionGroup},
     adw,
-    adw::prelude::{AdwApplicationWindowExt, NavigationPageExt},
+    adw::prelude::*,
     component::{AsyncComponent, AsyncComponentController},
-    gtk,
     gtk::{
         gio, glib,
         prelude::{ApplicationExt, ButtonExt, GtkWindowExt, OrientableExt, SettingsExt, WidgetExt},
@@ -18,6 +21,8 @@ use relm4::{
     prelude::AsyncController,
     shared_state::Reducer,
 };
+
+use ashpd::documents::Documents;
 
 use crate::adaptive;
 use crate::config::{APP_ID, PROFILE};
@@ -31,7 +36,9 @@ use fotema_core::people;
 
 use h3o::CellIndex;
 
-use std::path::PathBuf;
+use regex::Regex;
+
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -39,9 +46,11 @@ use anyhow::*;
 
 use strum::{AsRefStr, EnumString, FromRepr, IntoStaticStr};
 
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 mod components;
+
+use crate::host_path;
 
 use self::components::{
     about::AboutDialog,
@@ -117,8 +126,13 @@ pub struct Settings {
     /// the picture library root directory?
     pub is_onboarding_complete: bool,
 
-    /// Base path of pictures directory.
+    /// Base path of pictures directory inside Flatpak sandbox.
+    /// Will be under `/run/users/<uid>/docs/<doc-id>/...`
     pub pictures_base_dir: PathBuf,
+
+    /// Real base path outside of Flatpak sandbox.
+    /// For example, `/var/home/<user>/Pictures`.
+    pub pictures_base_dir_host_path: PathBuf,
 }
 
 /// Active settings
@@ -256,8 +270,8 @@ relm4::new_action_group!(pub(super) WindowActionGroup, "win");
 relm4::new_stateless_action!(PreferencesAction, WindowActionGroup, "preferences");
 relm4::new_stateless_action!(AboutAction, WindowActionGroup, "about");
 
-#[relm4::component(pub)]
-impl SimpleComponent for App {
+#[relm4::component(pub async)]
+impl SimpleAsyncComponent for App {
     type Init = ();
     type Input = AppMsg;
     type Output = ();
@@ -513,11 +527,11 @@ impl SimpleComponent for App {
         }
     }
 
-    fn init(
+    async fn init(
         _init: Self::Init,
         root: Self::Root,
-        sender: ComponentSender<Self>,
-    ) -> ComponentParts<Self> {
+        sender: AsyncComponentSender<Self>,
+    ) -> AsyncComponentParts<Self> {
         let data_dir = glib::user_data_dir().join(APP_ID);
         let _ = std::fs::create_dir_all(&data_dir);
 
@@ -536,7 +550,7 @@ impl SimpleComponent for App {
         let adaptive_layout = Arc::new(adaptive::LayoutState::new());
 
         let settings_state = SettingsState::new(relm4::SharedState::new());
-        match App::load_settings() {
+        match App::load_settings().await {
             std::result::Result::Ok(settings) => {
                 info!("Loaded settings: {:?}", settings);
                 *settings_state.write() = settings;
@@ -835,10 +849,10 @@ impl SimpleComponent for App {
             model.onboard_view.set_visible(true);
         }
 
-        ComponentParts { model, widgets }
+        AsyncComponentParts { model, widgets }
     }
 
-    fn update(&mut self, message: Self::Input, sender: ComponentSender<Self>) {
+    async fn update(&mut self, message: Self::Input, sender: AsyncComponentSender<Self>) {
         match message {
             AppMsg::Activate(width) => {
                 if width >= 500 {
@@ -1059,9 +1073,16 @@ impl SimpleComponent for App {
 }
 
 impl App {
-    pub fn load_settings() -> Result<Settings> {
+    pub async fn load_settings() -> Result<Settings> {
         info!("Loading settings");
+
         let gio_settings = gio::Settings::new(APP_ID);
+
+        let pic_base_dir: PathBuf =  path_encoding::from_base64(
+                &gio_settings.string("pictures-base-dir-b64").into())?;
+
+        let pic_base_dir_host_path = host_path::host_path(&pic_base_dir).await.unwrap_or(pic_base_dir.clone());
+
         Ok(Settings {
             show_selfies: gio_settings.boolean("show-selfies"),
             face_detection_mode: FaceDetectionMode::from_str(
@@ -1071,9 +1092,8 @@ impl App {
             album_sort: AlbumSort::from_str(&gio_settings.string("album-sort"))
                 .unwrap_or(AlbumSort::Ascending),
             is_onboarding_complete: gio_settings.boolean("onboarding-complete"),
-            pictures_base_dir: path_encoding::from_base64(
-                &gio_settings.string("pictures-base-dir-b64").into(),
-            )?,
+            pictures_base_dir: pic_base_dir,
+            pictures_base_dir_host_path: pic_base_dir_host_path,
         })
     }
 
@@ -1088,7 +1108,33 @@ impl App {
             "pictures-base-dir-b64",
             &path_encoding::to_base64(settings.pictures_base_dir.as_ref()),
         )?;
+        gio_settings.set_string(
+            "pictures-base-dir-host-path-b64",
+            &path_encoding::to_base64(settings.pictures_base_dir_host_path.as_ref()),
+        )?;
         Ok(())
+    }
+
+    pub async fn host_path(pic_base_dir: &Path) -> Option<PathBuf> {
+        // Parse Document ID from file chooser path.
+        let doc_id = pic_base_dir
+            .to_str()
+            .and_then(|s| {
+                let re = Regex::new(r"^/run/user/[0-9]+/doc/([0-9a-fA-F]+)/")
+                    .unwrap();
+                re.captures(s)
+            })
+            .and_then(|re_match| re_match.get(1))
+            .map(|doc_id_match| doc_id_match.as_str());
+
+        if let Some(doc_id) = doc_id {
+            debug!("Document ID={:?}", doc_id);
+            let proxy = Documents::new().await.unwrap();
+            let hp = proxy.host_paths(&[doc_id.into()]).await.unwrap();
+            info!("Host path={:?}", hp);
+        }
+
+        None
     }
 }
 

--- a/src/app/background/bootstrap.rs
+++ b/src/app/background/bootstrap.rs
@@ -394,6 +394,7 @@ impl Bootstrap {
     fn build_controllers(
         &mut self,
         pic_base_dir: PathBuf,
+        pic_base_host_path: Option<PathBuf>,
         sender: &ComponentSender<Self>,
     ) -> anyhow::Result<Controllers> {
         let data_dir = glib::user_data_dir().join(APP_ID);
@@ -692,7 +693,7 @@ impl Worker for Bootstrap {
                     "Configuring with pictures base directory: {:?}",
                     pictures_base_dir
                 );
-                match self.build_controllers(pictures_base_dir.clone(), &sender) {
+                match self.build_controllers(pictures_base_dir.clone(), None, &sender) {
                     Ok(controllers) => {
                         self.pictures_base_dir = Some(pictures_base_dir);
                         self.controllers = Some(controllers);

--- a/src/app/components/onboard.rs
+++ b/src/app/components/onboard.rs
@@ -102,26 +102,6 @@ impl SimpleAsyncComponent for Onboard {
                                 return;
                             };
                             info!("User has chosen picture library at: {:?}", dir);
-
-                            // Parse Document ID from file chooser path.
-                            let doc_id = dir
-                                .to_str()
-                                .and_then(|s| {
-                                    let re = Regex::new(r"^/run/user/[0-9]+/doc/([0-9a-fA-F]+)/")
-                                        .unwrap();
-                                    re.captures(s)
-                                })
-                                .and_then(|re_match| re_match.get(1))
-                                .map(|doc_id_match| doc_id_match.as_str());
-
-                            if let Some(doc_id) = doc_id {
-                                debug!("Document ID={:?}", doc_id);
-                                // TODO use XDG Documents API go get host path from doc_id
-                                //let proxy = Documents::new().await.unwrap();
-                                //let hp = proxy.host_paths(&[doc_id]).await.unwrap();
-                                //info!("Host paths={:?}", hp);
-                            }
-
                             let _ = sender.output(OnboardOutput::Done(dir));
                         }
                         Err(err) => {
@@ -133,3 +113,4 @@ impl SimpleAsyncComponent for Onboard {
         }
     }
 }
+

--- a/src/app/components/preferences.rs
+++ b/src/app/components/preferences.rs
@@ -14,6 +14,7 @@ use crate::app::AlbumSort;
 use crate::app::FaceDetectionMode;
 use crate::app::{Settings, SettingsState};
 use crate::fl;
+use crate::host_path;
 
 pub struct PreferencesDialog {
     parent: adw::ApplicationWindow,
@@ -31,12 +32,11 @@ impl PreferencesDialog {
         self.settings.face_detection_mode == FaceDetectionMode::On
     }
 
-    pub fn picture_base_dir_name(&self) -> String {
+    pub fn picture_base_dir_host_path(&self) -> String {
         self.settings
-            .pictures_base_dir
-            .file_name()
-            .map(|s| String::from(s.to_string_lossy()))
-            .unwrap_or(String::from(""))
+            .pictures_base_dir_host_path
+            .to_string_lossy()
+            .to_string()
     }
 }
 
@@ -127,7 +127,7 @@ impl SimpleAsyncComponent for PreferencesDialog {
                         set_title: &fl!("prefs-library-section-pictures-dir", "title"),
 
                         #[watch]
-                        set_subtitle: &model.picture_base_dir_name(),
+                        set_subtitle: &model.picture_base_dir_host_path(),
 
                         add_suffix = &gtk::Button {
                             set_valign: gtk::Align::Center,
@@ -235,7 +235,9 @@ impl SimpleAsyncComponent for PreferencesDialog {
                                             "New pictures base director is: {:?}",
                                             pictures_base_dir
                                         );
-                                        self.settings.pictures_base_dir = pictures_base_dir;
+                                        self.settings.pictures_base_dir = pictures_base_dir.clone();
+                                        self.settings.pictures_base_dir_host_path = host_path::host_path(&pictures_base_dir)
+                                            .await.unwrap_or(pictures_base_dir);
                                         *self.settings_state.write() = self.settings.clone();
                                     }
                                 }
@@ -250,3 +252,4 @@ impl SimpleAsyncComponent for PreferencesDialog {
         }
     }
 }
+

--- a/src/host_path.rs
+++ b/src/host_path.rs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2024 David Bliss
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use ashpd::documents::{DocumentID, Documents};
+use regex::Regex;
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+/// Derive host path from sandbox document path.
+pub async fn host_path(pic_base_dir: &Path) -> Option<PathBuf> {
+    // Parse Document ID from file chooser path.
+    let doc_id: Option<DocumentID> = pic_base_dir
+        .to_str()
+        .and_then(|s| {
+            let re = Regex::new(r"^/run/user/[0-9]+/doc/([0-9a-fA-F]+)/").unwrap();
+            re.captures(s)
+        })
+        .and_then(|re_match| re_match.get(1))
+        .map(|doc_id_match| doc_id_match.as_str().into());
+
+    if let Some(doc_id) = doc_id {
+        debug!("Document ID={:?}", doc_id);
+        let proxy = Documents::new().await.unwrap();
+        let host_paths = proxy.host_paths(&[doc_id.clone()]).await.unwrap();
+        let host_path = host_paths
+            .get(&doc_id)
+            .map(|file_path| file_path.as_ref().to_path_buf());
+        host_path
+    } else {
+        None
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 mod app;
 mod adaptive;
 mod config;
+mod host_path;
 mod languages;
 
 use app::App;
@@ -88,5 +89,5 @@ fn main() {
         )
         .unwrap();
     relm4::set_global_css(&glib::GString::from_utf8_checked(data.to_vec()).unwrap());
-    app.visible_on_activate(false).run::<App>(());
+    app.visible_on_activate(false).run_async::<App>(());
 }


### PR DESCRIPTION
This PR retrieves the host path for files when displaying paths to the user. This means that in the "preferences" screen the full real directory path of the library can be displayed, and when clicking "Open Containing Folder" the real containing folder can be opened.

Fixes #256 