### PR TITLE
Fix thumbnail failures

### DIFF
--- a/core/src/photo/thumbnailer.rs
+++ b/core/src/photo/thumbnailer.rs
@@ -10,6 +10,7 @@ use gdk4::prelude::TextureExt;
 use glycin;
 use std::io::Cursor;
 use std::path::Path;
+use tracing::info;
 
 use crate::thumbnailify;
 
@@ -35,6 +36,9 @@ impl PhotoThumbnailer {
                 host_path.to_string_lossy()
             );
         }
+
+        let exists = sandbox_path.exists();
+        info!("Photo sandbox path exists? {exists}");
 
         self.thumbnail_internal(host_path, sandbox_path)
             .await

--- a/core/src/photo/thumbnailer.rs
+++ b/core/src/photo/thumbnailer.rs
@@ -37,9 +37,6 @@ impl PhotoThumbnailer {
             );
         }
 
-        let exists = sandbox_path.exists();
-        info!("Photo sandbox path exists? {exists}");
-
         self.thumbnail_internal(host_path, sandbox_path)
             .await
             .map_err(|err| {

--- a/core/src/thumbnailify/thumbnailer.rs
+++ b/core/src/thumbnailify/thumbnailer.rs
@@ -168,6 +168,7 @@ pub fn generate_thumbnail(
     // Prepare a temporary file in the same directory as the final thumbnail.
     // Using `tempfile_in` ensures that the temp file is on the same filesystem
     // so that we can atomically persist (rename) it.
+    info!("thumb_path={:?}", thumb_path);
     let thumb_dir = thumb_path.parent().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::Other,

--- a/core/src/thumbnailify/thumbnailer.rs
+++ b/core/src/thumbnailify/thumbnailer.rs
@@ -133,6 +133,7 @@ pub fn generate_thumbnail(
     size: ThumbnailSize,
     src_image: DynamicImage,
 ) -> Result<PathBuf, ThumbnailError> {
+    info!("Generating thumbnail for hostpath: {:?}", host_path);
     let abs_path = host_path.canonicalize()?;
     info!("canonicalized path: {:?}", abs_path);
 

--- a/core/src/thumbnailify/thumbnailer.rs
+++ b/core/src/thumbnailify/thumbnailer.rs
@@ -133,13 +133,15 @@ pub fn generate_thumbnail(
     size: ThumbnailSize,
     src_image: DynamicImage,
 ) -> Result<PathBuf, ThumbnailError> {
-    info!("Generating thumbnail for hostpath: {:?}", host_path);
-    let abs_path = host_path.canonicalize()?;
-    info!("canonicalized path: {:?}", abs_path);
+    // info!("Generating thumbnail for hostpath: {:?}", host_path);
 
-    let _ = abs_path
-        .to_str()
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid file path"))?;
+    // `canonicalize()` will fail if `host_path` does not exist... which means
+    // that it will __never work__ inside the Flatpak sandbox.
+    // let abs_path = host_path.canonicalize()?;
+
+    //let _ = abs_path
+    //    .to_str()
+    //   .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid file path"))?;
 
     let file_uri = get_file_uri(host_path)?;
 
@@ -158,7 +160,6 @@ pub fn generate_thumbnail(
 
     // Determine the expected output thumbnail path.
     let thumb_path = get_thumbnail_hash_output(thumbnails_base_dir, &hash, size);
-    info!("thumb_path={:?}", thumb_path);
 
     // If the thumbnail already exists and is up to date, return it immediately.
     if thumb_path.exists() && is_thumbnail_up_to_date(&thumb_path, sandbox_path) {

--- a/core/src/thumbnailify/thumbnailer.rs
+++ b/core/src/thumbnailify/thumbnailer.rs
@@ -206,8 +206,10 @@ pub fn generate_thumbnail(
     let dst_height = (src_height * scale) as u32;
     let mut dst_image = Image::new(dst_width, dst_height, fr::PixelType::U8x4);
 
+    // By default uses a slow but high-quality thumbnail generator.
     let mut resizer = Resizer::new();
-    resizer.resize(&src_image, &mut dst_image, &ResizeOptions::new())?;
+    let resize_options = ResizeOptions::new();
+    resizer.resize(&src_image, &mut dst_image, &resize_options)?;
 
     let file = std::fs::File::create(&temp_path)?;
     let file = BufWriter::new(file);

--- a/core/src/thumbnailify/thumbnailer.rs
+++ b/core/src/thumbnailify/thumbnailer.rs
@@ -134,6 +134,7 @@ pub fn generate_thumbnail(
     src_image: DynamicImage,
 ) -> Result<PathBuf, ThumbnailError> {
     let abs_path = host_path.canonicalize()?;
+    info!("canonicalized path: {:?}", abs_path);
 
     let _ = abs_path
         .to_str()
@@ -156,6 +157,7 @@ pub fn generate_thumbnail(
 
     // Determine the expected output thumbnail path.
     let thumb_path = get_thumbnail_hash_output(thumbnails_base_dir, &hash, size);
+    info!("thumb_path={:?}", thumb_path);
 
     // If the thumbnail already exists and is up to date, return it immediately.
     if thumb_path.exists() && is_thumbnail_up_to_date(&thumb_path, sandbox_path) {
@@ -168,7 +170,6 @@ pub fn generate_thumbnail(
     // Prepare a temporary file in the same directory as the final thumbnail.
     // Using `tempfile_in` ensures that the temp file is on the same filesystem
     // so that we can atomically persist (rename) it.
-    info!("thumb_path={:?}", thumb_path);
     let thumb_dir = thumb_path.parent().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::Other,


### PR DESCRIPTION
Generating thumbnails worked when Fotema was run through GNOME Builder, but would fail when I was testing the release build produced by the Flatpak build infrastructure.

Problem was that host paths cannot be "canonicalised" inside the Flatpak sandbox because only a path that exists can be canonicalised.. Annoyingly, when run through GNOME Builder my home directory is fully available, meaning that the canonicalisation worked.