### PR TITLE
Faster face detection

### DIFF
--- a/THUMBNAILS.md
+++ b/THUMBNAILS.md
@@ -30,4 +30,4 @@ cache [cleanup policies](https://davejansen.com/increase-thumbnail-cache-in-ubun
 
 ## Thumbnail size
 
-Fotema generates thumbnails of both the "large" and "x-large" size.
+Fotema generates thumbnails of both the "large" and "x-large" sizes.

--- a/THUMBNAILS.md
+++ b/THUMBNAILS.md
@@ -30,41 +30,4 @@ cache [cleanup policies](https://davejansen.com/increase-thumbnail-cache-in-ubun
 
 ## Thumbnail size
 
-Fotema generates thumbnails of the "large" size, which makes the longest edge of
-the thumbnail 256 pixels. In my testing about 12,000 thumbnails takes a little over 1GB of storage.
-Your mileage may vary.
-
-## Using Fotema thumbnails for your system
-
-If you want to use Fotema's thumbnails for your system, then you can symlink
-your thumbnail cache to Fotema's thumbnail cache--but be aware that you will
-probably lose thumbnails unless you reconfigure the thumbnail cache cleanup policies.
-
-To use Fotema's thumbnail cache for your system:
-
-```bash
-rm -rf ~/.cache/thumbnails
-ln -s ~/.var/app/app.fotema.Fotema/cache/app.fotema.Fotema/thumbnails ~/.cache/thumbnails
-```
-
-## Packaging for non-Flatpak systems
-
-If you are packaging Fotema for a non-Flatpak system, then I suggest you keep
-Fotema's thumbnails in their default location to give your users
-the least surprising experience.
-
-However, if you wish to cause Fotema to use the user's default thumbnail cache, then
-you must patch the following files to change the thumbnail cache path:
-
-* `app.rs`
-* `bootstrap.rs`
-
-Look for the lines with the comment "Remove to use standard XDG thumbnail path".
-Example code:
-
-```rust
-let thumbnail_dir = glib::user_cache_dir()
-    .join(APP_ID) // Remove to use standard XDG thumbnail path
-    .join("thumbnails");
-```
-
+Fotema generates thumbnails of both the "large" and "x-large" size.

--- a/core/src/machine_learning/face_extractor.rs
+++ b/core/src/machine_learning/face_extractor.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use crate::people::FaceDetectionCandidate;
 use crate::photo::model::PictureId;
+
 use anyhow::*;
 
 use super::nms::Nms;
@@ -164,15 +166,10 @@ impl FaceExtractor {
     }
 
     /// Identify faces in a photo and return a vector of paths of extracted face images.
-    pub async fn extract_faces(
-        &self,
-        picture_id: &PictureId,
-        picture_path: &Path,
-    ) -> Result<Vec<Face>> {
-        // return Ok(vec![]);
-        info!("Detecting faces in {:?}", picture_path);
+    pub async fn extract_faces(&self, candidate: &FaceDetectionCandidate) -> Result<Vec<Face>> {
+        info!("Detecting faces in {:?}", candidate.sandbox_path);
 
-        let original_image = Self::open_image(picture_path).await?;
+        let original_image = Self::open_image(&candidate.sandbox_path).await?;
 
         let image = original_image.clone().into_rgb8().into_array3();
 
@@ -216,16 +213,16 @@ impl FaceExtractor {
 
         debug!(
             "Picture {} has {} faces. Found: {:?}",
-            picture_id,
+            candidate.picture_id,
             faces.len(),
             faces
         );
 
         let base_path = {
             // Create a directory per 1000 thumbnails
-            let partition = (picture_id.id() / 1000) as i32;
+            let partition = (candidate.picture_id.id() / 1000) as i32;
             let partition = format!("{:0>4}", partition);
-            let file_name = format!("{}", picture_id);
+            let file_name = format!("{}", candidate.picture_id);
             self.base_path.join(partition).join(file_name)
         };
 

--- a/core/src/machine_learning/face_extractor.rs
+++ b/core/src/machine_learning/face_extractor.rs
@@ -14,13 +14,11 @@ use std::path::{Path, PathBuf};
 use std::result::Result::Ok;
 
 use rust_faces::{
-    BlazeFaceParams, Face as DetectedFace, FaceDetection, FaceDetectorBuilder, InferParams,
-    Provider, ToArray3,
+    BlazeFaceParams, Face as DetectedFace, FaceDetection, FaceDetectorBuilder, ToArray3,
 };
 
 use gdk4::prelude::TextureExt;
 use image::DynamicImage;
-use itertools::*;
 use tracing::{debug, error, info};
 
 #[derive(Debug, Clone)]
@@ -109,59 +107,62 @@ impl FaceExtractor {
         // 640. Half default. Misses a mix of some larger, some smaller.
         // 320. Quarter default. Matches only very big faces.
 
-        let bz_params_huge = BlazeFaceParams {
-            score_threshold: 0.95,
-            target_size: 160,
-            ..BlazeFaceParams::default()
-        };
+        /*
+                let bz_params_huge = BlazeFaceParams {
+                    score_threshold: 0.95,
+                    target_size: 160,
+                    ..BlazeFaceParams::default()
+                };
 
-        let blaze_face_huge =
-            FaceDetectorBuilder::new(FaceDetection::BlazeFace640(bz_params_huge.clone()))
-                .download()
-                .build()?;
+                let blaze_face_huge =
+                    FaceDetectorBuilder::new(FaceDetection::BlazeFace640(bz_params_huge.clone()))
+                        .download()
+                        .build()?;
 
-        //detectors.push((blaze_face_huge, "blaze_face_640_huge".into()));
+                //detectors.push((blaze_face_huge, "blaze_face_640_huge".into()));
 
-        let blaze_face_huge = FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_huge))
-            .download()
-            .build()?;
+                let blaze_face_huge = FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_huge))
+                    .download()
+                    .build()?;
 
-        //detectors.push((blaze_face_huge, "blaze_face_320_huge".into()));
+                //detectors.push((blaze_face_huge, "blaze_face_320_huge".into()));
 
-        let bz_params_big = BlazeFaceParams {
-            score_threshold: 0.95,
-            target_size: 640,
-            ..BlazeFaceParams::default()
-        };
+                let bz_params_big = BlazeFaceParams {
+                    score_threshold: 0.95,
+                    target_size: 640,
+                    ..BlazeFaceParams::default()
+                };
 
-        let blaze_face_big =
-            FaceDetectorBuilder::new(FaceDetection::BlazeFace640(bz_params_big.clone()))
-                .download()
-                .build()?;
+                let blaze_face_big =
+                    FaceDetectorBuilder::new(FaceDetection::BlazeFace640(bz_params_big.clone()))
+                        .download()
+                        .build()?;
 
-        //detectors.push((blaze_face_big, "blaze_face_640_big".into()));
+                //detectors.push((blaze_face_big, "blaze_face_640_big".into()));
 
-        let blaze_face_big = FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_big))
-            .download()
-            .build()?;
+                let blaze_face_big = FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_big))
+                    .download()
+                    .build()?;
 
-        //detectors.push((blaze_face_big, "blaze_face_320_big".into()));
-
-        let bz_params_small = BlazeFaceParams::default();
+                //detectors.push((blaze_face_big, "blaze_face_320_big".into()));
+        */
+        let bz_params_default = BlazeFaceParams::default();
 
         let blaze_face_default =
-            FaceDetectorBuilder::new(FaceDetection::BlazeFace640(bz_params_small.clone()))
+            FaceDetectorBuilder::new(FaceDetection::BlazeFace640(bz_params_default.clone()))
                 .download()
                 .build()?;
 
         detectors.push((blaze_face_default, "blaze_face_640_default".into()));
 
+        /*
         let blaze_face_default =
             FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_small))
                 .download()
                 .build()?;
 
-        //detectors.push((blaze_face_default, "blaze_face_320_default".into()));
+        detectors.push((blaze_face_default, "blaze_face_320_default".into()));
+        */
 
         let mtcnn_params = rust_faces::MtCnnParams::default();
 
@@ -207,7 +208,7 @@ impl FaceExtractor {
 
         // Use "non-maxima suppression" to remove duplicate matches.
         let nms = Nms::default();
-        let mut faces = nms.suppress_non_maxima(faces);
+        let faces = nms.suppress_non_maxima(faces);
 
         debug!(
             "Picture {} has {} faces.",

--- a/core/src/machine_learning/face_extractor.rs
+++ b/core/src/machine_learning/face_extractor.rs
@@ -188,7 +188,7 @@ impl FaceExtractor {
 
     /// Identify faces in a photo and return a vector of paths of extracted face images.
     pub async fn extract_faces(&self, candidate: &FaceDetectionCandidate) -> Result<Vec<Face>> {
-        info!("Detecting faces in {:?}", candidate.sandbox_path);
+        info!("Detecting faces in {:?}", candidate.host_path);
 
         let thumbnail_hash = candidate.thumbnail_hash();
 
@@ -223,7 +223,6 @@ impl FaceExtractor {
             error!("Failed extracting faces with blaze_face_big: {:?}", result);
         }
 
-        /*
         let result = self.blaze_face_small.detect(image.view().into_dyn());
         if let Ok(detected_faces) = result {
             for f in detected_faces {
@@ -234,7 +233,7 @@ impl FaceExtractor {
                 "Failed extracting faces with blaze_face_small: {:?}",
                 result
             );
-        }*/
+        }
 
         let result = self.blaze_face_huge.detect(image.view().into_dyn());
         if let Ok(detected_faces) = result {

--- a/core/src/machine_learning/face_extractor.rs
+++ b/core/src/machine_learning/face_extractor.rs
@@ -120,13 +120,13 @@ impl FaceExtractor {
                 .download()
                 .build()?;
 
-        detectors.push((blaze_face_huge, "blaze_face_640_huge".into()));
+        //detectors.push((blaze_face_huge, "blaze_face_640_huge".into()));
 
         let blaze_face_huge = FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_huge))
             .download()
             .build()?;
 
-        detectors.push((blaze_face_huge, "blaze_face_320_huge".into()));
+        //detectors.push((blaze_face_huge, "blaze_face_320_huge".into()));
 
         let bz_params_big = BlazeFaceParams {
             score_threshold: 0.95,
@@ -139,29 +139,29 @@ impl FaceExtractor {
                 .download()
                 .build()?;
 
-        detectors.push((blaze_face_big, "blaze_face_640_big".into()));
+        //detectors.push((blaze_face_big, "blaze_face_640_big".into()));
 
         let blaze_face_big = FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_big))
             .download()
             .build()?;
 
-        detectors.push((blaze_face_big, "blaze_face_320_big".into()));
+        //detectors.push((blaze_face_big, "blaze_face_320_big".into()));
 
         let bz_params_small = BlazeFaceParams::default();
 
-        let blaze_face_small =
+        let blaze_face_default =
             FaceDetectorBuilder::new(FaceDetection::BlazeFace640(bz_params_small.clone()))
                 .download()
                 .build()?;
 
-        detectors.push((blaze_face_small, "blaze_face_640_small".into()));
+        detectors.push((blaze_face_default, "blaze_face_640_default".into()));
 
-        let blaze_face_small =
+        let blaze_face_default =
             FaceDetectorBuilder::new(FaceDetection::BlazeFace320(bz_params_small))
                 .download()
                 .build()?;
 
-        detectors.push((blaze_face_small, "blaze_face_320_small".into()));
+        //detectors.push((blaze_face_default, "blaze_face_320_default".into()));
 
         let mtcnn_params = rust_faces::MtCnnParams::default();
 
@@ -189,7 +189,6 @@ impl FaceExtractor {
             .get_thumbnail_path(&thumbnail_hash, ThumbnailSize::XLarge);
 
         let original_image = Self::open_image(&image_path).await?;
-        //let original_image = Self::open_image(&candidate.sandbox_path).await?;
 
         let image = original_image.clone().into_rgb8().into_array3();
 
@@ -215,19 +214,6 @@ impl FaceExtractor {
             candidate.picture_id,
             faces.len()
         );
-
-        faces.sort_by_key(|x| x.1.clone());
-
-        //      let mut faces_flat_grouped: Vec<(String, usize, DetectedFace)> = Vec::new();
-
-        /*
-        for (model_name, chunk) in &faces.into_iter().chunk_by(|x| x.1.clone()) {
-            let mut vs = chunk
-                .enumerate()
-                .map(|(i, x)| (model_name.clone(), i, x.0))
-                .collect::<Vec<(String, usize, DetectedFace)>>();
-            faces_flat_grouped.append(&mut vs);
-        }*/
 
         let faces = faces
             .into_iter()

--- a/core/src/machine_learning/face_extractor.rs
+++ b/core/src/machine_learning/face_extractor.rs
@@ -203,17 +203,17 @@ impl FaceExtractor {
 
         let mut faces: Vec<(DetectedFace, String)> = vec![];
 
-        /*
-                let result = self.mtcnn.detect(image.view().into_dyn());
-                if let Ok(detected_faces) = result {
-                    for f in detected_faces {
-                        faces.push((f, "mtcnn".into()));
-                    }
-                } else {
-                    error!("Failed extracting faces with MTCNN: {:?}", result);
-                }
-        */
 
+        let result = self.mtcnn.detect(image.view().into_dyn());
+        if let Ok(detected_faces) = result {
+            for f in detected_faces {
+                faces.push((f, "mtcnn".into()));
+            }
+        } else {
+            error!("Failed extracting faces with MTCNN: {:?}", result);
+        }
+
+/*
         let result = self.blaze_face_big.detect(image.view().into_dyn());
         if let Ok(detected_faces) = result {
             for f in detected_faces {
@@ -222,6 +222,7 @@ impl FaceExtractor {
         } else {
             error!("Failed extracting faces with blaze_face_big: {:?}", result);
         }
+        */
 
         let result = self.blaze_face_small.detect(image.view().into_dyn());
         if let Ok(detected_faces) = result {
@@ -234,7 +235,7 @@ impl FaceExtractor {
                 result
             );
         }
-
+/*
         let result = self.blaze_face_huge.detect(image.view().into_dyn());
         if let Ok(detected_faces) = result {
             for f in detected_faces {
@@ -243,6 +244,7 @@ impl FaceExtractor {
         } else {
             error!("Failed extracting faces with blaze_face_huge: {:?}", result);
         }
+        */
 
         // Use "non-maxima suppression" to remove duplicate matches.
         let nms = Nms::default();

--- a/core/src/people/mod.rs
+++ b/core/src/people/mod.rs
@@ -5,6 +5,7 @@
 pub mod model;
 pub mod repo;
 
+pub use model::FaceDetectionCandidate;
 pub use model::FaceId;
 pub use model::Person;
 pub use model::PersonId;

--- a/core/src/people/model.rs
+++ b/core/src/people/model.rs
@@ -2,11 +2,25 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::photo::model::Orientation;
+use crate::photo::model::{Orientation, PictureId};
+use crate::thumbnailify;
 use chrono::{DateTime, Utc};
 use opencv::core::Mat;
 use std::fmt::Display;
 use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct FaceDetectionCandidate {
+    pub picture_id: PictureId,
+    pub host_path: PathBuf,
+    pub sandbox_path: PathBuf,
+}
+
+impl FaceDetectionCandidate {
+    pub fn thumbnail_hash(&self) -> String {
+        thumbnailify::compute_hash_for_path(&self.host_path)
+    }
+}
 
 /// Database ID
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/core/src/photo/repo.rs
+++ b/core/src/photo/repo.rs
@@ -475,6 +475,32 @@ impl Repository {
         Ok(result)
     }
 
+    /// Gets all pictures that haven't been scanned for faces.
+    /// This method is not on the people repo because I don't what that repo
+    /// to need a pic_base_dir.
+    pub fn get_face_detection_candidate(
+        &self,
+        picture_id: &PictureId,
+    ) -> Result<Option<FaceDetectionCandidate>> {
+        let con = self.con.lock().unwrap();
+        let mut stmt = con.prepare(
+            "SELECT
+                    pictures.picture_id,
+                    pictures.picture_path_b64,
+                FROM pictures
+                WHERE pictures.picture_id = ?1",
+        )?;
+
+        let result = stmt
+            .query_map([picture_id.id()], |row| {
+                self.to_face_detection_candidate(row)
+            })?
+            .flatten()
+            .nth(0);
+
+        Ok(result)
+    }
+
     fn to_face_detection_candidate(
         &self,
         row: &Row<'_>,

--- a/core/src/photo/repo.rs
+++ b/core/src/photo/repo.rs
@@ -415,38 +415,6 @@ impl Repository {
     /// Gets all pictures that haven't been scanned for faces.
     /// This method is not on the people repo because I don't what that repo
     /// to need a pic_base_dir.
-    // deprecated. use find_face_detection_candidates.
-    pub fn find_need_face_scan(&self) -> Result<Vec<(PictureId, PathBuf)>> {
-        let con = self.con.lock().unwrap();
-        let mut stmt = con.prepare(
-            "SELECT
-                    pictures.picture_id,
-                    pictures.picture_path_b64,
-                    COALESCE(
-                        pictures.exif_created_ts,
-                        pictures.exif_modified_ts,
-                        pictures.fs_created_ts,
-                        pictures.fs_modified_ts,
-                        CURRENT_TIMESTAMP
-                    ) AS ordering_ts
-                FROM pictures
-                LEFT OUTER JOIN pictures_face_scans USING (picture_id)
-                WHERE pictures_face_scans.picture_id IS NULL
-                AND COALESCE(pictures.is_broken, FALSE) IS FALSE
-                ORDER BY ordering_ts DESC",
-        )?;
-
-        let result = stmt
-            .query_map([], |row| self.to_picture_id_path_tuple(row))?
-            .flatten()
-            .collect();
-
-        Ok(result)
-    }
-
-    /// Gets all pictures that haven't been scanned for faces.
-    /// This method is not on the people repo because I don't what that repo
-    /// to need a pic_base_dir.
     pub fn find_face_detection_candidates(&self) -> Result<Vec<FaceDetectionCandidate>> {
         let con = self.con.lock().unwrap();
         let mut stmt = con.prepare(
@@ -523,35 +491,5 @@ impl Repository {
             host_path: host_path.expect("Must have host path"),
             sandbox_path: sandbox_path.expect("Must have sandbox path"),
         })
-    }
-
-    pub fn get_picture_path(&self, picture_id: PictureId) -> Result<Option<PathBuf>> {
-        let con = self.con.lock().unwrap();
-        let mut stmt = con.prepare(
-            "SELECT
-                    pictures.picture_id,
-                    pictures.picture_path_b64
-                FROM pictures
-                WHERE pictures.picture_id = ?1",
-        )?;
-
-        let result = stmt
-            .query_map([picture_id.id()], |row| self.to_picture_id_path_tuple(row))?
-            .flatten()
-            .nth(0)
-            .map(|x| x.1);
-
-        Ok(result)
-    }
-
-    fn to_picture_id_path_tuple(&self, row: &Row<'_>) -> rusqlite::Result<(PictureId, PathBuf)> {
-        let picture_id = row.get("picture_id").map(PictureId::new)?;
-
-        let relative_path: String = row.get("picture_path_b64")?;
-        let relative_path = path_encoding::from_base64(&relative_path)
-            .map_err(|_| rusqlite::Error::InvalidQuery)?;
-        let sandbox_path = self.library_sandbox_base_path.join(relative_path);
-
-        std::result::Result::Ok((picture_id, sandbox_path))
     }
 }

--- a/core/src/photo/thumbnailer.rs
+++ b/core/src/photo/thumbnailer.rs
@@ -69,6 +69,13 @@ impl PhotoThumbnailer {
             host_path,
             sandbox_path,
             thumbnailify::ThumbnailSize::Large,
+            src_image.clone(),
+        )?;
+
+        let _ = self.thumbnailer.generate_thumbnail(
+            host_path,
+            sandbox_path,
+            thumbnailify::ThumbnailSize::XLarge,
             src_image,
         )?;
 

--- a/core/src/thumbnailify/file.rs
+++ b/core/src/thumbnailify/file.rs
@@ -129,14 +129,19 @@ pub fn write_failed_thumbnail(
 /// `input` must be a host path.
 pub fn get_file_uri(input: &Path) -> Result<String, ThumbnailError> {
     debug!("Attempting to get file URI for path: {:?}", input);
-    // Attempt to canonicalize the input to get the full file path.
-    let canonical = std::fs::canonicalize(input).unwrap_or_else(|_| {
-        debug!(
-            "Failed to canonicalize path: {:?}, using the raw path as fallback",
-            input
-        );
-        PathBuf::from(input)
-    });
+    // Attempt to canonicalize the input to get the full file path.#
+    // `canonicalize()` will fail if `host_path` does not exist... which means
+    // that it will __never work__ inside the Flatpak sandbox.
+
+    //let canonical = std::fs::canonicalize(input).unwrap_or_else(|_| {
+    //    debug!(
+    //        "Failed to canonicalize path: {:?}, using the raw path as fallback",
+    //        input
+    //    );
+    //    PathBuf::from(input)
+    //});
+    let canonical = PathBuf::from(input);
+
     let url = Url::from_file_path(&canonical).map_err(|_| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/core/src/thumbnailify/mod.rs
+++ b/core/src/thumbnailify/mod.rs
@@ -44,6 +44,10 @@ impl Thumbnailer {
         thumbnailer::is_thumbnail_up_to_date(&self.thumbnails_path, host_path)
     }
 
+    pub fn get_thumbnail_path(&self, hash: &str, size: ThumbnailSize) -> PathBuf {
+        get_thumbnail_hash_output(&self.thumbnails_path, hash, size)
+    }
+
     /**
      * Compute thumbnail path, or sensible fallback if preferred size does not exist.
      * If no thumbnails exist, then return preferred path pointing to absent file.

--- a/core/src/thumbnailify/thumbnailer.rs
+++ b/core/src/thumbnailify/thumbnailer.rs
@@ -210,7 +210,8 @@ pub fn generate_thumbnail(
     let dst_height = (src_height * scale) as u32;
     let mut dst_image = Image::new(dst_width, dst_height, fr::PixelType::U8x4);
 
-    // By default uses a slow but high-quality thumbnail generator.
+    // By default uses a slow but high-quality thumbnail algorithm.
+    // Configure to use a lower-quality (but still good) and faster algorithm.
     let mut resizer = Resizer::new();
     let resize_options = ResizeOptions::new().resize_alg(
         fast_image_resize::ResizeAlg::Convolution(fast_image_resize::FilterType::Hamming),

--- a/core/src/thumbnailify/thumbnailer.rs
+++ b/core/src/thumbnailify/thumbnailer.rs
@@ -212,7 +212,9 @@ pub fn generate_thumbnail(
 
     // By default uses a slow but high-quality thumbnail generator.
     let mut resizer = Resizer::new();
-    let resize_options = ResizeOptions::new();
+    let resize_options = ResizeOptions::new().resize_alg(
+        fast_image_resize::ResizeAlg::Convolution(fast_image_resize::FilterType::Hamming),
+    );
     resizer.resize(&src_image, &mut dst_image, &resize_options)?;
 
     let file = std::fs::File::create(&temp_path)?;

--- a/data/app.fotema.Fotema.metainfo.xml.in.in
+++ b/data/app.fotema.Fotema.metainfo.xml.in.in
@@ -124,7 +124,7 @@
         </p>
         <ul>
           <li>BREAKING CHANGE: Fotema requires version 1.20.0+ of the xdg-desktop-portal.</li>
-          <li>No unsightly large gaps between album columns.</li>
+          <li>Faster face recognition.</li>
           <li>Display full directory path of photo library in preferences dialog.</li>
           <li>No longer need to transcode HEVC videos.</li>
         </ul>

--- a/src/app/background/bootstrap.rs
+++ b/src/app/background/bootstrap.rs
@@ -451,7 +451,7 @@ impl Bootstrap {
             self.con.clone(),
         )?;
 
-        let video_thumbnailer = video::VideoThumbnailer::build(thumbnailer)?;
+        let video_thumbnailer = video::VideoThumbnailer::build(thumbnailer.clone())?;
 
         let motion_photo_extractor = photo::MotionPhotoExtractor::build(&cache_dir)?;
 
@@ -619,6 +619,7 @@ impl Bootstrap {
             .detach_worker((
                 stop.clone(),
                 data_dir,
+                thumbnailer,
                 photo_repo.clone(),
                 people_repo.clone(),
                 self.progress_monitor.clone(),

--- a/src/app/background/bootstrap.rs
+++ b/src/app/background/bootstrap.rs
@@ -410,8 +410,8 @@ pub struct Bootstrap {
 impl Bootstrap {
     fn build_controllers(
         &mut self,
-        pic_base_dir: PathBuf,
-        pic_base_dir_host_path: PathBuf,
+        library_sandbox_base_path: PathBuf,
+        library_host_base_path: PathBuf,
         sender: &ComponentSender<Self>,
     ) -> anyhow::Result<Controllers> {
         let data_dir = glib::user_data_dir().join(APP_ID);
@@ -429,11 +429,11 @@ impl Bootstrap {
 
         let thumbnailer = Thumbnailer::build(&thumbnail_dir);
 
-        let photo_scanner = photo::Scanner::build(&pic_base_dir)?;
+        let photo_scanner = photo::Scanner::build(&library_sandbox_base_path)?;
 
         let photo_repo = photo::Repository::open(
-            &pic_base_dir,
-            &pic_base_dir_host_path,
+            &library_sandbox_base_path,
+            &library_host_base_path,
             &cache_dir,
             &data_dir,
             self.con.clone(),
@@ -441,11 +441,11 @@ impl Bootstrap {
 
         let photo_thumbnailer = photo::PhotoThumbnailer::build(thumbnailer.clone())?;
 
-        let video_scanner = video::Scanner::build(&pic_base_dir)?;
+        let video_scanner = video::Scanner::build(&library_sandbox_base_path)?;
 
         let video_repo = video::Repository::open(
-            &pic_base_dir,
-            &pic_base_dir_host_path,
+            &library_sandbox_base_path,
+            &library_host_base_path,
             &cache_dir,
             &data_dir,
             self.con.clone(),
@@ -456,13 +456,15 @@ impl Bootstrap {
         let motion_photo_extractor = photo::MotionPhotoExtractor::build(&cache_dir)?;
 
         let visual_repo = visual::Repository::open(
-            &pic_base_dir,
-            &pic_base_dir_host_path,
+            &library_sandbox_base_path,
+            &library_host_base_path,
             &cache_dir,
             self.con.clone(),
         )?;
 
-        let people_repo = people::Repository::open(&data_dir, self.con.clone())?;
+        let people_repo = people::Repository::open(
+            &data_dir,
+            self.con.clone())?;
 
         let stop = Arc::new(AtomicBool::new(false));
 

--- a/src/app/background/photo_detect_faces_task.rs
+++ b/src/app/background/photo_detect_faces_task.rs
@@ -18,6 +18,7 @@ use tracing::{error, info};
 
 use fotema_core::machine_learning::face_extractor::FaceExtractor;
 use fotema_core::people;
+use fotema_core::people::FaceDetectionCandidate;
 use fotema_core::photo;
 use fotema_core::photo::PictureId;
 
@@ -55,9 +56,9 @@ pub struct PhotoDetectFacesTask {
 impl PhotoDetectFacesTask {
     fn detect_for_one(&self, sender: ComponentSender<Self>, picture_id: PictureId) -> Result<()> {
         self.people_repo.delete_faces(picture_id)?;
-        let result = self.photo_repo.get_picture_path(picture_id)?;
-        if let Some(picture_path) = result {
-            let unprocessed = vec![(picture_id, picture_path)];
+        let result = self.photo_repo.get_face_detection_candidate(&picture_id)?;
+        if let Some(candidate) = result {
+            let unprocessed = vec![candidate];
             self.detect(sender, unprocessed)
         } else {
             Err(anyhow!("No file to scan"))
@@ -65,11 +66,11 @@ impl PhotoDetectFacesTask {
     }
 
     fn detect_for_all(&self, sender: ComponentSender<Self>) -> Result<()> {
-        let unprocessed: Vec<(PictureId, PathBuf)> = self
+        let unprocessed: Vec<FaceDetectionCandidate> = self
             .photo_repo
-            .find_need_face_scan()?
+            .find_face_detection_candidates()?
             .into_iter()
-            .filter(|(_, path)| path.exists())
+            .filter(|candidate| candidate.sandbox_path.exists())
             .collect();
 
         self.detect(sender, unprocessed)
@@ -78,7 +79,7 @@ impl PhotoDetectFacesTask {
     fn detect(
         &self,
         sender: ComponentSender<Self>,
-        unprocessed: Vec<(PictureId, PathBuf)>,
+        unprocessed: Vec<FaceDetectionCandidate>,
     ) -> Result<()> {
         let start = std::time::Instant::now();
 
@@ -108,20 +109,20 @@ impl PhotoDetectFacesTask {
             //.into_iter()
             .par_iter()
             .take_any_while(|_| !self.stop.load(Ordering::Relaxed))
-            .for_each(|(picture_id, path)| {
+            .for_each(|candidate| {
                 let mut repo = self.people_repo.clone();
 
                 // Careful! panic::catch_unwind returns Ok(Err) if the evaluated expression returns
                 // an error but doesn't panic.
-                let result = block_on(async { extractor.extract_faces(picture_id, path).await })
-                    .and_then(|faces| repo.clone().add_face_scans(picture_id, &faces));
+                let result = block_on(async { extractor.extract_faces(&candidate.picture_id, &candidate.sandbox_path).await })
+                    .and_then(|faces| repo.clone().add_face_scans(&candidate.picture_id, &faces));
 
                 if result.is_err() {
                     error!(
                         "Failed detecting faces: Photo path: {:?}. Error: {:?}",
-                        path, result
+                        candidate.sandbox_path, result
                     );
-                    let _ = repo.mark_face_scan_broken(picture_id);
+                    let _ = repo.mark_face_scan_broken(&candidate.picture_id);
                 }
 
                 self.progress_monitor.emit(ProgressMonitorInput::Advance);

--- a/src/app/background/photo_detect_faces_task.rs
+++ b/src/app/background/photo_detect_faces_task.rs
@@ -114,7 +114,7 @@ impl PhotoDetectFacesTask {
 
                 // Careful! panic::catch_unwind returns Ok(Err) if the evaluated expression returns
                 // an error but doesn't panic.
-                let result = block_on(async { extractor.extract_faces(&candidate.picture_id, &candidate.sandbox_path).await })
+                let result = block_on(async { extractor.extract_faces(&candidate).await })
                     .and_then(|faces| repo.clone().add_face_scans(&candidate.picture_id, &faces));
 
                 if result.is_err() {


### PR DESCRIPTION
Run face detection against photo thumbnails instead of original images. For my setup it reduces an hour of face detection down to about 10 minutes for my whole library. Also reduces storage requirements for face dection.

Trade-offs:

* Face thumbnails are smaller and grainier because they themselves are extracted form a thumbnail, not the original image.
* Person recognition might not be as accurate.