### PR TITLE
Motion photo setting

### DIFF
--- a/data/app.fotema.Fotema.gschema.xml.in
+++ b/data/app.fotema.Fotema.gschema.xml.in
@@ -34,5 +34,9 @@
       <default>'L3Zhci9lbXB0eQ=='</default>
       <summary>Sandbox view of user selected pictures directory. Base64 encoded because paths aren't strings. Default is /var/empty</summary>
     </key>
+    <key name="process-motion-photos" type="b">
+      <default>false</default>
+      <summary>Extract videos from Android motion photos.</summary>
+    </key>
   </schema>
 </schemalist>

--- a/data/app.fotema.Fotema.metainfo.xml.in.in
+++ b/data/app.fotema.Fotema.metainfo.xml.in.in
@@ -125,8 +125,11 @@
         <ul>
           <li>BREAKING CHANGE: Fotema requires version 1.20.0+ of the xdg-desktop-portal.</li>
           <li>Faster face recognition.</li>
-          <li>Display full directory path of photo library in preferences dialog.</li>
           <li>No longer need to transcode HEVC videos.</li>
+          <li>Add setting to enable or disable Android motion photo processing.</li>
+          <li>Enabling face detection now applies immediately.</li>
+          <li>Re-organize settings.</li>
+          <li>Display full directory path of photo library in preferences dialog.</li>
         </ul>
       </description>
     </release>

--- a/i18n/en-US/fotema.ftl
+++ b/i18n/en-US/fotema.ftl
@@ -224,17 +224,17 @@ people-not-this-person = Not { $name }
 prefs-title = Preferences
 
 # Title of section of preferences for views
-prefs-ui-section = UI
-  .description = Tweak the user interface.
+prefs-albums-section = Albums
+  .description = Configure albums.
 
 # Selfies page enabled or disabled.
 # Attributes:
-#   .subtitle - Description of toggle button action action.
-prefs-ui-selfies = Selfies
+#   .subtitle - Description of toggle button action.
+prefs-albums-selfies = Selfies
   .subtitle = Shows a separate album for selfies taken on iOS devices. Restart {-app-name} to apply.
 
 # Album sort drop-down menu
-prefs-ui-chronological-album-sort = Sort Order
+prefs-albums-chronological-sort = Sort order
   .subtitle = Chronological sort order for albums.
   .ascending = Ascending
   .descending = Descending
@@ -242,12 +242,18 @@ prefs-ui-chronological-album-sort = Sort Order
 # Preferences related to machine learning, such as face detection.
 # Machine learning is CPU intensive so capabilities can be turned on or off by
 # the user
-prefs-machine-learning-section = Machine Learning
-  .description = Configure machine learning features.
+prefs-processing-section = Photo and video processing
+  .description = Configure photo and video processing features.
 
 # Enable or disable face detection
-prefs-machine-learning-face-detection = Face Detection
-  .subtitle = Enable face detection when { -app-name } launches. This is a time consuming process.
+prefs-processing-face-detection = Face detection
+  .subtitle = Detect faces and recognize people you've named. This is a time consuming process.
+
+# Motion photo processing enabled or disabled.
+# Attributes:
+#   .subtitle - Description of toggle button action.
+prefs-processing-motion-photos = Motion photos
+  .subtitle = Detect Android motion photos and extract the videos.
 
 prefs-library-section =
   .title = Library


### PR DESCRIPTION
Add a setting to enable or disable Android motion photo processing. The only Android motion photos I have are the ones I downloaded for testing purposes, so I'd like the processing to be optional.