### PR TITLE
Flatpak path

### DIFF
--- a/core/src/flatpak_path.rs
+++ b/core/src/flatpak_path.rs
@@ -5,9 +5,16 @@
 use crate::thumbnailify;
 use std::path::PathBuf;
 
+/// A path to a file that exists both inside and outside of the Flatpak sandbox.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FlatpakPathBuf {
+    /// Path on the host system. This is the path to display in the UI and to use
+    /// when computing thumbnail hashes.
+    /// Fotema likely won't be able to read from this path.
     pub host_path: PathBuf,
+
+    /// Path inside the sandbox, likely under `/run/user/$UID/docs/$DOC_ID/...`.
+    /// This is the path to use when reading a file.
     pub sandbox_path: PathBuf,
 }
 

--- a/core/src/flatpak_path.rs
+++ b/core/src/flatpak_path.rs
@@ -6,7 +6,8 @@ use crate::thumbnailify;
 use std::path::PathBuf;
 
 /// A path to a file that exists both inside and outside of the Flatpak sandbox.
-#[derive(Debug, Clone, Eq, PartialEq)]
+/// FIXME does Default make sense? It is here to make Settings compile.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct FlatpakPathBuf {
     /// Path on the host system. This is the path to display in the UI and to use
     /// when computing thumbnail hashes.

--- a/core/src/flatpak_path.rs
+++ b/core/src/flatpak_path.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2024 David Bliss
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use crate::thumbnailify;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FlatpakPathBuf {
+    pub host_path: PathBuf,
+    pub sandbox_path: PathBuf,
+}
+
+impl FlatpakPathBuf {
+    pub fn build(
+        host_path: impl Into<PathBuf>,
+        sandbox_path: impl Into<PathBuf>,
+    ) -> FlatpakPathBuf {
+        FlatpakPathBuf {
+            host_path: host_path.into(),
+            sandbox_path: sandbox_path.into(),
+        }
+    }
+
+    pub fn thumbnail_hash(&self) -> String {
+        thumbnailify::compute_hash_for_path(&self.host_path)
+    }
+
+    pub fn exists(&self) -> bool {
+        self.sandbox_path.exists()
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 pub mod database;
+pub mod flatpak_path;
 pub mod machine_learning;
 pub mod path_encoding;
 pub mod people;
@@ -13,6 +14,7 @@ pub mod time;
 pub mod video;
 pub mod visual;
 
+pub use flatpak_path::FlatpakPathBuf;
 pub use people::model::FaceId;
 pub use people::model::PersonId;
 pub use photo::model::PictureId;

--- a/core/src/photo/model.rs
+++ b/core/src/photo/model.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::gps::GPSLocation;
-use crate::thumbnailify;
+use crate::FlatpakPathBuf;
+
 use chrono::{DateTime, FixedOffset, TimeDelta, Utc};
 use std::fmt::Display;
 use std::path::PathBuf;
@@ -33,12 +34,8 @@ impl Display for PictureId {
 /// A picture in the repository
 #[derive(Debug, Clone)]
 pub struct Picture {
-    /// Full path from picture library root.
-    /// This path is inside the sandbox.
-    pub path: PathBuf,
-
-    /// Full path on host system (outside of Flatpak sandbox).
-    pub host_path: PathBuf,
+    /// Path to picture
+    pub path: FlatpakPathBuf,
 
     /// Database primary key for picture
     pub picture_id: PictureId,
@@ -52,7 +49,15 @@ pub struct Picture {
 
 impl Picture {
     pub fn thumbnail_hash(&self) -> String {
-        thumbnailify::compute_hash_for_path(&self.host_path)
+        self.path.thumbnail_hash()
+    }
+
+    pub fn host_path(&self) -> &PathBuf {
+        &self.path.host_path
+    }
+
+    pub fn sandbox_path(&self) -> &PathBuf {
+        &self.path.sandbox_path
     }
 }
 

--- a/core/src/photo/repo.rs
+++ b/core/src/photo/repo.rs
@@ -18,6 +18,7 @@ use rusqlite::Row;
 use rusqlite::params;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+use tracing::error;
 
 /// Repository of picture metadata.
 /// Repository is backed by a Sqlite database.
@@ -187,6 +188,8 @@ impl Repository {
                         link_path_b64,
                         link_path.to_string_lossy(),
                     ])?;
+                } else {
+                    error!("Expected a photo, but got: {:?}", scanned_file);
                 }
             }
         }

--- a/core/src/photo/repo.rs
+++ b/core/src/photo/repo.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use crate::FlatpakPathBuf;
 use crate::ScannedFile;
 use crate::path_encoding;
 use crate::people::model::FaceDetectionCandidate;
@@ -387,8 +388,7 @@ impl Repository {
 
         std::result::Result::Ok(Picture {
             picture_id,
-            path: sandbox_path,
-            host_path,
+            path: FlatpakPathBuf::build(host_path, sandbox_path),
             ordering_ts,
             is_selfie,
         })

--- a/core/src/photo/thumbnailer.rs
+++ b/core/src/photo/thumbnailer.rs
@@ -9,9 +9,9 @@ use image::ImageReader;
 use gdk4::prelude::TextureExt;
 use glycin;
 use std::io::Cursor;
-use std::path::Path;
 use tracing::error;
 
+use crate::FlatpakPathBuf;
 use crate::thumbnailify;
 
 /// Thumbnail operations for photos.
@@ -29,34 +29,30 @@ impl PhotoThumbnailer {
 
     /// Computes a preview square for an image that has been inserted
     /// into the Repository. Preview image will be written to file system and path returned.
-    pub async fn thumbnail(&self, host_path: &Path, sandbox_path: &Path) -> Result<()> {
-        if self.thumbnailer.is_failed(host_path) {
-            anyhow::bail!(
-                "Failed thumbnail marker exists for {:?}",
-                host_path.to_string_lossy()
-            );
+    pub async fn thumbnail(&self, path: &FlatpakPathBuf) -> Result<()> {
+        if self.thumbnailer.is_failed(&path.host_path) {
+            anyhow::bail!("Failed thumbnail marker exists for {:?}", path.host_path);
         }
 
-        self.thumbnail_internal(host_path, sandbox_path)
-            .await
-            .map_err(|err| {
-                let _ = self
-                    .thumbnailer
-                    .write_failed_thumbnail(&host_path, sandbox_path);
-                err
-            })
+        self.thumbnail_internal(path).await.map_err(|err| {
+            let _ = self.thumbnailer.write_failed_thumbnail(path);
+            err
+        })
     }
 
-    async fn thumbnail_internal(&self, host_path: &Path, sandbox_path: &Path) -> Result<()> {
-        let file = gio::File::for_path(sandbox_path);
+    async fn thumbnail_internal(&self, path: &FlatpakPathBuf) -> Result<()> {
+        let file = gio::File::for_path(&path.sandbox_path);
         let loader = glycin::Loader::new(file);
         let image = loader.load().await.map_err(|err| {
-            error!("Glycin failed to load file at {:?}", sandbox_path);
+            error!("Glycin failed to load file at {:?}", path.sandbox_path);
             err
         })?;
 
         let frame = image.next_frame().await.map_err(|err| {
-            error!("Glycin failed to fetch next frame from {:?}", sandbox_path);
+            error!(
+                "Glycin failed to fetch next frame from {:?}",
+                path.sandbox_path
+            );
             err
         })?;
 
@@ -66,15 +62,13 @@ impl PhotoThumbnailer {
             ImageReader::with_format(Cursor::new(bytes), image::ImageFormat::Png).decode()?;
 
         let _ = self.thumbnailer.generate_thumbnail(
-            host_path,
-            sandbox_path,
+            path,
             thumbnailify::ThumbnailSize::Large,
             src_image.clone(),
         )?;
 
         let _ = self.thumbnailer.generate_thumbnail(
-            host_path,
-            sandbox_path,
+            path,
             thumbnailify::ThumbnailSize::XLarge,
             src_image,
         )?;

--- a/core/src/thumbnailify/mod.rs
+++ b/core/src/thumbnailify/mod.rs
@@ -19,6 +19,8 @@ pub use file::write_failed_thumbnail;
 pub use sizes::ThumbnailSize;
 pub use thumbnailer::generate_thumbnail;
 
+use crate::FlatpakPathBuf;
+
 pub fn compute_hash_for_path(host_path: &Path) -> String {
     let file_uri = file::get_file_uri(host_path).unwrap();
     hash::compute_hash(&file_uri)
@@ -88,24 +90,13 @@ impl Thumbnailer {
 
     pub fn generate_thumbnail(
         &self,
-        host_path: &Path,
-        sandbox_path: &Path,
+        path: &FlatpakPathBuf,
         size: ThumbnailSize,
         src_image: DynamicImage,
     ) -> Result<PathBuf, ThumbnailError> {
-        thumbnailer::generate_thumbnail(
-            &self.thumbnails_path,
-            host_path,
-            sandbox_path,
-            size,
-            src_image,
-        )
+        thumbnailer::generate_thumbnail(&self.thumbnails_path, path, size, src_image)
     }
-    pub fn write_failed_thumbnail(
-        &self,
-        host_path: &Path,
-        sandbox_path: &Path,
-    ) -> Result<(), ThumbnailError> {
-        file::write_failed_thumbnail(&self.thumbnails_path, host_path, sandbox_path)
+    pub fn write_failed_thumbnail(&self, path: &FlatpakPathBuf) -> Result<(), ThumbnailError> {
+        file::write_failed_thumbnail(&self.thumbnails_path, path)
     }
 }

--- a/core/src/video/model.rs
+++ b/core/src/video/model.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::thumbnailify;
+use crate::FlatpakPathBuf;
 use chrono::{DateTime, TimeDelta, Utc};
 use std::fmt::Display;
 use std::path::PathBuf;
@@ -31,11 +31,8 @@ impl Display for VideoId {
 /// Video in database
 #[derive(Debug, Clone)]
 pub struct Video {
-    /// Full path from library root. Inside sandbox.
-    pub path: PathBuf,
-
-    /// Full path from host system library root. Outside sandbox.
-    pub host_path: PathBuf,
+    /// Path to video.
+    pub path: FlatpakPathBuf,
 
     /// Database primary key for video
     pub video_id: VideoId,
@@ -55,7 +52,15 @@ pub struct Video {
 
 impl Video {
     pub fn thumbnail_hash(&self) -> String {
-        thumbnailify::compute_hash_for_path(&self.host_path)
+        self.path.thumbnail_hash()
+    }
+
+    pub fn host_path(&self) -> &PathBuf {
+        &self.path.host_path
+    }
+
+    pub fn sandbox_path(&self) -> &PathBuf {
+        &self.path.sandbox_path
     }
 }
 

--- a/core/src/video/repo.rs
+++ b/core/src/video/repo.rs
@@ -22,12 +22,8 @@ use tracing::error;
 /// Repository is backed by a Sqlite database.
 #[derive(Debug, Clone)]
 pub struct Repository {
-    /// Base path to picture library on file system
-    library_base_path: PathBuf,
-
-    /// Base path to picture library on file system.
-    /// This is the path outside of the Flatpak sandbox.
-    library_base_dir_host_path: PathBuf,
+    /// Base path to library
+    library_base_dir: FlatpakPathBuf,
 
     /// Base path for transcoded videos
     cache_dir_base_path: PathBuf,
@@ -42,8 +38,7 @@ pub struct Repository {
 impl Repository {
     /// Builds a Repository and creates operational tables.
     pub fn open(
-        library_base_path: &Path,
-        library_base_dir_host_path: &Path,
+        library_base_dir: &FlatpakPathBuf,
         cache_dir_base_path: &Path,
         data_dir_base_path: &Path,
         con: Arc<Mutex<rusqlite::Connection>>,
@@ -51,8 +46,7 @@ impl Repository {
         std::fs::create_dir_all(cache_dir_base_path)?;
 
         let repo = Repository {
-            library_base_path: library_base_path.into(),
-            library_base_dir_host_path: library_base_dir_host_path.into(),
+            library_base_dir: library_base_dir.clone(),
             cache_dir_base_path: cache_dir_base_path.into(),
             data_dir_base_path: data_dir_base_path.into(),
             con,
@@ -164,7 +158,9 @@ impl Repository {
             for scanned_file in vids {
                 if let ScannedFile::Video(info) = scanned_file {
                     // convert to relative path before saving to database
-                    let video_path = info.path.strip_prefix(&self.library_base_path)?;
+                    let video_path = info
+                        .path
+                        .strip_prefix(&self.library_base_dir.sandbox_path)?;
                     let video_path_b64 = path_encoding::to_base64(video_path);
 
                     // Path without suffix so sibling pictures and videos can be related
@@ -267,8 +263,8 @@ impl Repository {
         let relative_path: String = row.get("video_path_b64")?;
         let relative_path = path_encoding::from_base64(&relative_path)
             .map_err(|_| rusqlite::Error::InvalidQuery)?;
-        let sandbox_path = self.library_base_path.join(&relative_path);
-        let host_path = self.library_base_dir_host_path.join(&relative_path);
+        let sandbox_path = self.library_base_dir.sandbox_path.join(&relative_path);
+        let host_path = self.library_base_dir.host_path.join(&relative_path);
 
         let ordering_ts = row.get("ordering_ts").expect("must have ordering_ts");
 

--- a/core/src/visual/model.rs
+++ b/core/src/visual/model.rs
@@ -5,6 +5,7 @@
 use std::fmt::Display;
 use std::path::PathBuf;
 
+use crate::FlatpakPathBuf;
 use crate::photo::model::Orientation;
 use crate::thumbnailify;
 use crate::{PictureId, VideoId, YearMonth};
@@ -46,9 +47,7 @@ pub struct Visual {
 
     pub video_id: Option<VideoId>,
 
-    pub video_path: Option<PathBuf>,
-
-    pub video_host_path: Option<PathBuf>,
+    pub video_path: Option<FlatpakPathBuf>,
 
     // Transcoded version of video_path of video_codec is not supported.
     pub video_transcoded_path: Option<PathBuf>,
@@ -61,9 +60,7 @@ pub struct Visual {
 
     pub picture_id: Option<PictureId>,
 
-    pub picture_path: Option<PathBuf>,
-
-    pub picture_host_path: Option<PathBuf>,
+    pub picture_path: Option<FlatpakPathBuf>,
 
     pub picture_orientation: Option<Orientation>,
 
@@ -86,19 +83,23 @@ pub struct Visual {
 }
 
 impl Visual {
-    pub fn path(&self) -> Option<&PathBuf> {
-        self.picture_path.as_ref().or(self.video_path.as_ref())
+    pub fn path(&self) -> &FlatpakPathBuf {
+        self.picture_path
+            .as_ref()
+            .or(self.video_path.as_ref())
+            .expect("Must have either picture path or video path")
     }
 
-    // FIXME not an option! One must always be present.
-    pub fn host_path(&self) -> Option<&PathBuf> {
-        self.picture_host_path
-            .as_ref()
-            .or(self.video_host_path.as_ref())
+    pub fn sandbox_path(&self) -> &PathBuf {
+        &self.path().sandbox_path
+    }
+
+    pub fn host_path(&self) -> &PathBuf {
+        &self.path().host_path
     }
 
     pub fn thumbnail_hash(&self) -> String {
-        thumbnailify::compute_hash_for_path(&self.host_path().expect("Must have host path!"))
+        thumbnailify::compute_hash_for_path(self.host_path())
     }
 
     pub fn is_selfie(&self) -> bool {

--- a/src/app/background/library_scan_task.rs
+++ b/src/app/background/library_scan_task.rs
@@ -71,8 +71,9 @@ impl LibraryScanTask {
         self.video_repo.add_all(&videos).map_err(|e| e.to_string())?;
 
         info!(
-            "Scanned {} photos and videos in {} seconds.",
-            count,
+            "Scanned {} photos and {} videos in {} seconds.",
+            photos.len(),
+            videos.len(),
             start.elapsed().as_secs()
         );
 

--- a/src/app/background/library_scan_task.rs
+++ b/src/app/background/library_scan_task.rs
@@ -59,7 +59,6 @@ impl LibraryScanTask {
         info!("Scanning file system for pictures...");
 
         let result = self.scan.scan_all().map_err(|e| e.to_string())?;
-        let count = result.len();
 
         let (photos, videos) = result.into_iter().partition_map(|scanned_file|
             match scanned_file {

--- a/src/app/background/photo_enrich_task.rs
+++ b/src/app/background/photo_enrich_task.rs
@@ -61,7 +61,7 @@ impl PhotoEnrichTask {
             .par_iter()
             .take_any_while(|_| !stop.load(Ordering::Relaxed))
             .flat_map(|pic| {
-                let result = metadata::from_path(&pic.path);
+                let result = metadata::from_path(&pic.sandbox_path());
                 result.map(|m| (pic.picture_id, m))
             })
             .collect();

--- a/src/app/background/photo_extract_motion_task.rs
+++ b/src/app/background/photo_extract_motion_task.rs
@@ -80,7 +80,7 @@ impl PhotoExtractMotionTask {
             .par_iter()
             .take_any_while(|_| !stop.load(Ordering::Relaxed))
             .for_each(|photo| {
-                let result = extractor.extract(&photo.picture_id, &photo.path);
+                let result = extractor.extract(&photo.picture_id, photo.sandbox_path());
 
                 let result = match result {
                     Ok(opt_video) => repo

--- a/src/app/background/photo_thumbnail_task.rs
+++ b/src/app/background/photo_thumbnail_task.rs
@@ -107,7 +107,7 @@ impl PhotoThumbnailTask {
                 // Careful! panic::catch_unwind returns Ok(Err) if the evaluated expression returns
                 // an error but doesn't panic.
                 let result = panic::catch_unwind(|| {
-                    block_on(async { thumbnailer.thumbnail(&pic.host_path, &pic.path).await })
+                    block_on(async { thumbnailer.thumbnail(&pic.path.host_path, &pic.path.sandbox_path).await })
                 });
 
                 // If we got an err, then there was a panic.

--- a/src/app/background/photo_thumbnail_task.rs
+++ b/src/app/background/photo_thumbnail_task.rs
@@ -107,7 +107,7 @@ impl PhotoThumbnailTask {
                 // Careful! panic::catch_unwind returns Ok(Err) if the evaluated expression returns
                 // an error but doesn't panic.
                 let result = panic::catch_unwind(|| {
-                    block_on(async { thumbnailer.thumbnail(&pic.path.host_path, &pic.path.sandbox_path).await })
+                    block_on(async { thumbnailer.thumbnail(&pic.path).await })
                 });
 
                 // If we got an err, then there was a panic.

--- a/src/app/background/video_enrich_task.rs
+++ b/src/app/background/video_enrich_task.rs
@@ -71,7 +71,7 @@ impl VideoEnrichTask {
             .par_iter()
             .take_any_while(|_| !stop.load(Ordering::Relaxed))
             .flat_map(|vid| {
-                let result = metadata::from_path(&vid.path);
+                let result = metadata::from_path(&vid.sandbox_path());
                 progress_monitor.emit(ProgressMonitorInput::Advance);
                 result.map(|m| (vid.video_id, m))
             })

--- a/src/app/background/video_thumbnail_task.rs
+++ b/src/app/background/video_thumbnail_task.rs
@@ -102,7 +102,7 @@ impl VideoThumbnailTask {
                 // Careful! panic::catch_unwind returns Ok(Err) if the evaluated expression returns
                 // an error but doesn't panic.
                 let result =
-                    panic::catch_unwind(|| thumbnailer.thumbnail(&vid.host_path, &vid.path));
+                    panic::catch_unwind(|| thumbnailer.thumbnail(vid.host_path(), vid.sandbox_path()));
 
                 // If we got an err, then there was a panic.
                 // If we got Ok(Err(e)) there wasn't a panic, but we still failed.

--- a/src/app/background/video_thumbnail_task.rs
+++ b/src/app/background/video_thumbnail_task.rs
@@ -102,7 +102,7 @@ impl VideoThumbnailTask {
                 // Careful! panic::catch_unwind returns Ok(Err) if the evaluated expression returns
                 // an error but doesn't panic.
                 let result =
-                    panic::catch_unwind(|| thumbnailer.thumbnail(vid.host_path(), vid.sandbox_path()));
+                    panic::catch_unwind(|| thumbnailer.thumbnail(&vid.path));
 
                 // If we got an err, then there was a panic.
                 // If we got Ok(Err(e)) there wasn't a panic, but we still failed.

--- a/src/app/background/video_transcode_task.rs
+++ b/src/app/background/video_transcode_task.rs
@@ -79,7 +79,7 @@ impl VideoTranscodeTask {
 
                 let result = self
                     .transcoder
-                    .transcode(video_id, video_path)
+                    .transcode(video_id, &video_path.sandbox_path)
                     .with_context(|| format!("Video path: {:?}", video_path));
 
                 if let std::result::Result::Ok(ref transcode_path) = result {

--- a/src/app/components/preferences.rs
+++ b/src/app/components/preferences.rs
@@ -15,6 +15,7 @@ use crate::app::FaceDetectionMode;
 use crate::app::{Settings, SettingsState};
 use crate::fl;
 use crate::host_path;
+use fotema_core::FlatpakPathBuf;
 
 pub struct PreferencesDialog {
     parent: adw::ApplicationWindow,
@@ -34,7 +35,8 @@ impl PreferencesDialog {
 
     pub fn picture_base_dir_host_path(&self) -> String {
         self.settings
-            .pictures_base_dir_host_path
+            .library_base_dir
+            .host_path
             .to_string_lossy()
             .to_string()
     }
@@ -265,21 +267,20 @@ impl SimpleAsyncComponent for PreferencesDialog {
                             info!("Open: {:?}", files);
                             if let Some(first) = files.uris().first() {
                                 info!("User has chosen picture library at: {:?}", first.path());
-                                if let Some(pictures_base_dir) =
+                                if let Some(library_base_dir) =
                                     files.uris().first().and_then(|uri| uri.to_file_path().ok())
                                 {
                                     info!(
                                         "User has chosen picture library at: {:?}",
-                                        pictures_base_dir
+                                        library_base_dir
                                     );
-                                    if self.settings.pictures_base_dir != pictures_base_dir {
+                                    if self.settings.library_base_dir.sandbox_path != library_base_dir {
                                         info!(
                                             "New pictures base director is: {:?}",
-                                            pictures_base_dir
+                                            library_base_dir
                                         );
-                                        self.settings.pictures_base_dir = pictures_base_dir.clone();
-                                        self.settings.pictures_base_dir_host_path = host_path::host_path(&pictures_base_dir)
-                                            .await.unwrap_or(pictures_base_dir);
+                                        self.settings.library_base_dir = host_path::host_path(&library_base_dir)
+                                            .await.unwrap_or(FlatpakPathBuf::build(&library_base_dir, &library_base_dir));
                                         *self.settings_state.write() = self.settings.clone();
                                     }
                                 }

--- a/src/app/components/viewer/view_info.rs
+++ b/src/app/components/viewer/view_info.rs
@@ -19,7 +19,6 @@ use relm4::gtk;
 use relm4::gtk::gio;
 use relm4::prelude::*;
 use std::fs;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::app::SharedState;


### PR DESCRIPTION
Stop passing separate `host_path` and `sandbox_path` parameters, and instead pass a single `FlatpakPathBuf` parameter.