### PR TITLE
Re-add `StartupWMClass` to the desktop file

### DIFF
--- a/data/app.fotema.Fotema.desktop.in.in
+++ b/data/app.fotema.Fotema.desktop.in.in
@@ -9,6 +9,7 @@ Categories=GNOME;GTK;Photography;Viewer;
 Keywords=Gnome;GTK;Pictures;Photos;Photography;Viewer;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=@icon@
+StartupWMClass=@icon@
 StartupNotify=true
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
This should resolve any edge-cases where icon is not shown in Gnome's dash or in other desktop environments, in case there is a regression in compositor recognizing `wmclass` through the desktop filename.

It also respects XDG desktop standards:  
https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html