### PR TITLE
Fix crash when person thumbnail picture missing

### DIFF
--- a/core/src/people/repo.rs
+++ b/core/src/people/repo.rs
@@ -718,25 +718,29 @@ impl Repository {
         let small_thumbnail_path = row
             .get("person_thumbnail_path")
             .map(|p: String| self.data_dir_base_path.join(p))
-            .ok()
-            .expect("Must have small thumbnail path");
+            .ok();
 
         // FIXME should this path be in database?
-        let large_thumbnail_path = self
-            .cache_dir_base_path
-            .join("face_thumbnails")
-            .join("large")
-            .join(
-                small_thumbnail_path
-                    .file_name()
-                    .expect("Must have file name"),
-            );
+        let large_thumbnail_path = if let Some(ref small_thumbnail_path) = small_thumbnail_path {
+            Some(
+                self.cache_dir_base_path
+                    .join("face_thumbnails")
+                    .join("large")
+                    .join(
+                        small_thumbnail_path
+                            .file_name()
+                            .expect("Must have file name"),
+                    ),
+            )
+        } else {
+            None
+        };
 
         std::result::Result::Ok(model::Person {
             person_id,
             name,
-            small_thumbnail_path: Some(small_thumbnail_path),
-            large_thumbnail_path: Some(large_thumbnail_path),
+            small_thumbnail_path,
+            large_thumbnail_path,
         })
     }
 

--- a/data/app.fotema.Fotema.metainfo.xml.in.in
+++ b/data/app.fotema.Fotema.metainfo.xml.in.in
@@ -117,6 +117,13 @@
   </screenshots>
 
   <releases>
+    <release version="2.0.1" date="2025-06-23">
+      <description>
+        <ul>
+          <li>Fix crash when picture backing a person's thumbnail is deleted.</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.0.0" date="2025-06-21">
       <description>
         <p>Fotema has changed the way it generates thumbnails, which has the unfortunate


### PR DESCRIPTION
Fix #451.

When a user creates a person by assigning a name to a face, then that face becomes the person's thumbnail. If that photo is deleted or renamed, then the face record is deleted from Fotema's database, and when Fotema next tries to load the person it will fail because it expects the face thumbnail path to be present.

This PR allows the face thumbnail to be absent.