### PR TITLE
feat(bootstrap): log per-stage timing

### DIFF
--- a/src/app/background/bootstrap.rs
+++ b/src/app/background/bootstrap.rs
@@ -146,6 +146,9 @@ type Task = dyn Fn() + Send + Sync;
 pub struct Controllers {
     started_at: Option<Instant>,
 
+    /// When the currently-running task emitted TaskStarted, for per-stage timing.
+    task_started_at: Option<Instant>,
+
     shared_state: SharedState,
 
     settings_state: SettingsState,
@@ -230,9 +233,23 @@ impl Controllers {
             }
             BootstrapInput::TaskStarted(task_name) => {
                 info!("Task started: {:?}", task_name);
+                self.task_started_at = Some(Instant::now());
                 let _ = sender.output(BootstrapOutput::TaskStarted(task_name));
             }
             BootstrapInput::TaskCompleted(task_name, updated) => {
+                // Per-stage timing. take() so a TaskCompleted without a matching
+                // TaskStarted (e.g. LoadLibrary) doesn't report a bogus duration.
+                if let Some(started_at) = self.task_started_at.take() {
+                    info!(
+                        "Stage {:?} took {:?} ({:?} items)",
+                        task_name,
+                        started_at.elapsed(),
+                        updated
+                    );
+                }
+                if let Some(total_started_at) = self.started_at {
+                    info!("Total elapsed since bootstrap start: {:?}", total_started_at.elapsed());
+                }
                 info!(
                     "Task completed: {:?}. Items updated? {:?}",
                     task_name, updated
@@ -699,6 +716,7 @@ impl Bootstrap {
         let mut controllers = Controllers {
             stop,
             started_at: None,
+            task_started_at: None,
             shared_state: self.shared_state.clone(),
             settings_state: self.settings_state.clone(),
             load_library_task: Arc::new(load_library_task),

--- a/src/app/background/bootstrap.rs
+++ b/src/app/background/bootstrap.rs
@@ -248,7 +248,10 @@ impl Controllers {
                     );
                 }
                 if let Some(total_started_at) = self.started_at {
-                    info!("Total elapsed since bootstrap start: {:?}", total_started_at.elapsed());
+                    info!(
+                        "Total elapsed since bootstrap start: {:?}",
+                        total_started_at.elapsed()
+                    );
                 }
                 info!(
                     "Task completed: {:?}. Items updated? {:?}",


### PR DESCRIPTION

While profiling why the initial library/database build takes a while, I found
it hard to see where the time actually goes. This adds lightweight per-stage
timing to the bootstrap pipeline: when a background stage completes, it logs how
long it took and the running total since bootstrap started, e.g.

    Stage Enrich(Photo) took 12.3s (Some(842) items)
    Total elapsed since bootstrap start: 41.0s

It's purely additive `info!` logging (one `Instant` captured on TaskStarted,
read on TaskCompleted) — no behaviour change, no new dependencies. Handy for
anyone diagnosing slow first-run indexing.

Files: src/app/background/bootstrap.rs (+18)
