### PR TITLE
feat: optional VAAPI hardware video decode for thumbnails

### DIFF
--- a/core/src/video/hwaccel.rs
+++ b/core/src/video/hwaccel.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2024 David Bliss
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Optional VAAPI hardware-accelerated video decoding for thumbnail frame
+//! extraction.
+//!
+//! All `unsafe` FFI lives here so the upstream thumbnailer only needs a tiny,
+//! fallback-guarded hook. Every failure path returns to the caller's existing
+//! software decode, so enabling this can never make thumbnailing fail — only
+//! faster on machines with a working VAAPI driver (Intel/AMD, and NVIDIA via
+//! the VA driver).
+//!
+//! Set the environment variable `FOTEMA_DISABLE_VAAPI` to force software
+//! decoding (escape hatch for misbehaving drivers).
+
+use ffmpeg_next as ffmpeg;
+use ffmpeg::codec::context::Context;
+use ffmpeg::ffi::*;
+use ffmpeg::format::Pixel;
+use ffmpeg::util::frame::video::Video;
+
+use std::ptr;
+
+use tracing::{debug, warn};
+
+/// `get_format` callback: pick the VAAPI surface format when the decoder offers
+/// it, otherwise fall back to the decoder's preferred (software) format.
+unsafe extern "C" fn get_vaapi_format(
+    _ctx: *mut AVCodecContext,
+    formats: *const AVPixelFormat,
+) -> AVPixelFormat {
+    let vaapi: AVPixelFormat = Pixel::VAAPI.into();
+    let none: AVPixelFormat = Pixel::None.into();
+
+    unsafe {
+        let mut p = formats;
+        while *p != none {
+            if *p == vaapi {
+                return vaapi;
+            }
+            p = p.add(1);
+        }
+        // VAAPI not on offer: let the decoder use its first (software) choice.
+        *formats
+    }
+}
+
+/// Attach a VAAPI hardware device to `ctx` *before* it is opened. Returns true
+/// when hardware decoding was set up; false means the caller should decode in
+/// software. Must be called before [`Context::decoder`].
+pub fn setup_vaapi(ctx: &mut Context) -> bool {
+    if std::env::var_os("FOTEMA_DISABLE_VAAPI").is_some() {
+        debug!("VAAPI disabled via FOTEMA_DISABLE_VAAPI; using software decode");
+        return false;
+    }
+
+    unsafe {
+        let mut device: *mut AVBufferRef = ptr::null_mut();
+        let kind = av_hwdevice_find_type_by_name(c"vaapi".as_ptr());
+        let ret = av_hwdevice_ctx_create(&mut device, kind, ptr::null(), ptr::null_mut(), 0);
+        if ret < 0 || device.is_null() {
+            debug!("VAAPI unavailable (av_hwdevice_ctx_create = {ret}); using software decode");
+            return false;
+        }
+
+        let raw = ctx.as_mut_ptr();
+        (*raw).hw_device_ctx = av_buffer_ref(device);
+        (*raw).get_format = Some(get_vaapi_format);
+
+        // The codec context now holds its own reference; drop ours.
+        av_buffer_unref(&mut device);
+
+        debug!("VAAPI hardware decode enabled");
+        true
+    }
+}
+
+/// True when `frame` lives in a VAAPI surface and must be copied to system
+/// memory before software processing (scaling, PNG encode).
+pub fn is_hw_frame(frame: &Video) -> bool {
+    frame.format() == Pixel::VAAPI
+}
+
+/// Copy a hardware (VAAPI) frame into a freshly allocated software frame
+/// (typically NV12 or P010). The returned frame can be fed to swscale.
+pub fn transfer_to_software(hw: &Video) -> Result<Video, ffmpeg::Error> {
+    let mut sw = Video::empty();
+    unsafe {
+        let ret = av_hwframe_transfer_data(sw.as_mut_ptr(), hw.as_ptr(), 0);
+        if ret < 0 {
+            warn!("av_hwframe_transfer_data failed: {ret}");
+            return Err(ffmpeg::Error::from(ret));
+        }
+    }
+    Ok(sw)
+}

--- a/core/src/video/mod.rs
+++ b/core/src/video/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod display_matrix;
 
+mod hwaccel;
 pub mod metadata;
 pub mod model;
 pub mod repo;

--- a/core/src/video/thumbnailer.rs
+++ b/core/src/video/thumbnailer.rs
@@ -5,6 +5,7 @@
 use crate::FlatpakPathBuf;
 use crate::thumbnailify;
 use crate::video::display_matrix::av_display_rotation_get;
+use crate::video::hwaccel;
 
 use anyhow::*;
 use image::imageops;
@@ -58,26 +59,23 @@ impl VideoThumbnailer {
 
             let video_stream_index = input.index();
 
-            let context_decoder =
+            let mut context_decoder =
                 ffmpeg::codec::context::Context::from_parameters(input.parameters())?;
+            // Try VAAPI hardware decode; falls back to software on any failure.
+            let use_hw = hwaccel::setup_vaapi(&mut context_decoder);
             let mut decoder = context_decoder.decoder().video()?;
 
-            let mut scaler = Context::get(
-                decoder.format(),
-                decoder.width(),
-                decoder.height(),
-                Pixel::RGB24,
-                decoder.width(),
-                decoder.height(),
-                Flags::BILINEAR,
-            )?;
+            // Built lazily once the first frame's pixel format is known — for
+            // hardware decode that is only settled after the GPU→CPU transfer.
+            let mut scaler: Option<Context> = None;
 
             // Lambda for decoding video
             let mut receive_and_process_decoded_frames =
                 |decoder: &mut ffmpeg::decoder::Video| -> Result<(), ffmpeg::Error> {
                     let mut decoded = Video::empty();
                     if decoder.receive_frame(&mut decoded).is_ok() {
-                        // MatrixData contains rotation.
+                        // MatrixData contains rotation. Read it from the decoded
+                        // frame before any hardware transfer.
                         let display_matrix = decoded.side_data(SideDataType::DisplayMatrix);
                         let rotation = if let Some(display_matrix) = display_matrix {
                             av_display_rotation_get(display_matrix.data())
@@ -85,8 +83,30 @@ impl VideoThumbnailer {
                             f64::NAN
                         };
 
+                        // Copy a VAAPI surface into system memory; software
+                        // frames are used as-is.
+                        let frame = if use_hw && hwaccel::is_hw_frame(&decoded) {
+                            hwaccel::transfer_to_software(&decoded)
+                                .map_err(|_| ffmpeg::Error::Unknown)?
+                        } else {
+                            decoded
+                        };
+
+                        if scaler.is_none() {
+                            scaler = Some(Context::get(
+                                frame.format(),
+                                frame.width(),
+                                frame.height(),
+                                Pixel::RGB24,
+                                frame.width(),
+                                frame.height(),
+                                Flags::BILINEAR,
+                            )?);
+                        }
+                        let scaler = scaler.as_mut().unwrap();
+
                         let mut rgb_frame = Video::empty();
-                        scaler.run(&decoded, &mut rgb_frame)?;
+                        scaler.run(&frame, &mut rgb_frame)?;
                         Self::convert_rgb_to_png(&rgb_frame, rotation, temporary_png_file.path())
                             .map_err(|_| ffmpeg::Error::Unknown)?;
                     }


### PR DESCRIPTION

Video thumbnailing currently decodes frames purely on the CPU via ffmpeg-next.
On machines with an Intel iGPU this is the slowest part of building the library
for video-heavy collections. This adds optional VAAPI hardware decoding of the
frame used for the thumbnail.

Design goals were to keep upstream churn minimal and to never regress:

- All the unsafe FFI lives in a new, self-contained module
  `core/src/video/hwaccel.rs` (device setup via `av_hwdevice_ctx_create` for
  "vaapi", a `get_format` callback selecting `AV_PIX_FMT_VAAPI`, and
  `av_hwframe_transfer_data` to bring frames back to CPU memory as NV12).
- The only change in the existing `thumbnailer.rs` is to optionally route the
  decoder through `hwaccel::try_vaapi_decoder(...)`; on `None`/any error it falls
  straight back to the unchanged software path. The scaler is built lazily after
  the first decoded frame so it adapts to the transferred pixel format.
- Hard software fallback throughout — if VAAPI isn't available (no
  `/dev/dri/renderD128`, missing driver, unsupported codec) decoding proceeds on
  the CPU exactly as before.

Tested on Intel Iris Xe (Raptor Lake-P, iHD driver), H.264/HEVC decode
confirmed, with a pixel-diff check of HW vs SW output on sample files.

Packaging note: at runtime this needs a VA driver
(`intel-media-va-driver` / `mesa-va-drivers`); for Flatpak the freedesktop
runtime already ships the userspace bits and `/dev/dri` access is the usual
requirement.

Files: core/src/video/hwaccel.rs (new), core/src/video/mod.rs (+1),
core/src/video/thumbnailer.rs (+44/-12)

Happy to put it behind an explicit setting/env flag if you'd prefer it opt-in.
