### PR TITLE
feat: optional GitHub release update checker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ members = ["core"]
 lto = "thin"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+ureq = { version = "3", features = ["json"] }
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["chrono", "env-filter"] }

--- a/data/app.fotema.Fotema.gschema.xml.in
+++ b/data/app.fotema.Fotema.gschema.xml.in
@@ -38,5 +38,9 @@
       <default>false</default>
       <summary>Extract videos from Android motion photos.</summary>
     </key>
+    <key name="update-check-enabled" type="b">
+      <default>true</default>
+      <summary>Automatically check GitHub for a newer release on startup.</summary>
+    </key>
   </schema>
 </schemalist>

--- a/i18n/en-US/fotema.ftl
+++ b/i18n/en-US/fotema.ftl
@@ -354,6 +354,15 @@ primary-menu-preferences = Preferences
 # Menu item to show "about" dialog
 primary-menu-about = About {-app-name}
 
+# Menu item to check for application updates
+primary-menu-check-updates = Check for Updates
+
+# Toast shown when a newer release is available. $version is the new version number.
+update-available = Update available: { -app-name } { $version }
+
+# Toast shown when the installed version is current
+update-not-available = { -app-name } is up to date
+
 ## Person menu
 
 # Menu item to rename a person

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,7 @@ use relm4::{
 };
 
 use crate::adaptive;
-use crate::config::{APP_ID, PROFILE};
+use crate::config::{APP_ID, PROFILE, VERSION};
 use crate::fl;
 
 use fotema_core::FlatpakPathBuf;
@@ -46,6 +46,7 @@ use strum::{AsRefStr, FromRepr};
 use tracing::{error, info, warn};
 
 mod components;
+mod update_checker;
 
 use crate::host_path;
 
@@ -161,6 +162,9 @@ pub struct Settings {
     /// Enable processing of Android motion photos.
     pub process_motion_photos: bool,
 
+    /// Automatically check GitHub for a newer release on startup.
+    pub update_check_enabled: bool,
+
     /// Has the user completed the onboarding processes to select
     /// the picture library root directory?
     pub is_onboarding_complete: bool,
@@ -240,6 +244,9 @@ pub(super) struct App {
     // Message banner
     banner: adw::Banner,
 
+    // Toast overlay for update notifications
+    toast_overlay: adw::ToastOverlay,
+
     settings_state: SettingsState,
 }
 
@@ -301,11 +308,21 @@ pub(super) enum AppMsg {
 
     /// Onboarding process is complete and user has selected the picture base directory
     OnboardDone(PathBuf),
+
+    /// Manually trigger a check for updates.
+    CheckForUpdates,
+
+    /// A newer version is available on GitHub.
+    UpdateAvailable(String),
+
+    /// The installed version is up to date.
+    NoUpdateAvailable,
 }
 
 relm4::new_action_group!(pub(super) WindowActionGroup, "win");
 relm4::new_stateless_action!(PreferencesAction, WindowActionGroup, "preferences");
 relm4::new_stateless_action!(AboutAction, WindowActionGroup, "about");
+relm4::new_stateless_action!(CheckForUpdatesAction, WindowActionGroup, "check-for-updates");
 
 #[relm4::component(pub async)]
 impl SimpleAsyncComponent for App {
@@ -318,6 +335,7 @@ impl SimpleAsyncComponent for App {
         primary_menu: {
             section! {
                 &fl!("primary-menu-preferences") => PreferencesAction,
+                &fl!("primary-menu-check-updates") => CheckForUpdatesAction,
                 &fl!("primary-menu-about") => AboutAction,
             }
         }
@@ -359,7 +377,11 @@ impl SimpleAsyncComponent for App {
                 connect_unapply => AppMsg::Adapt(adaptive::Layout::Wide),
             },
 
-            gtk::Box {
+            #[local_ref]
+            toast_overlay -> adw::ToastOverlay {
+
+            #[wrap(Some)]
+            set_child = &gtk::Box {
                 set_orientation: gtk::Orientation::Vertical,
 
             // Top-level navigation view containing:
@@ -559,6 +581,7 @@ impl SimpleAsyncComponent for App {
 
                 #[wrap(Some)]
                 set_content = model.onboard.widget(),
+            }
             }
             }
         }
@@ -830,6 +853,8 @@ impl SimpleAsyncComponent for App {
             .tooltip_text(fl!("banner-button-stop", "tooltip"))
             .build();
 
+        let toast_overlay = adw::ToastOverlay::new();
+
         let model = Self {
             adaptive_layout,
             bootstrap,
@@ -864,6 +889,8 @@ impl SimpleAsyncComponent for App {
 
             banner: banner.clone(),
 
+            toast_overlay: toast_overlay.clone(),
+
             settings_state: settings_state.clone(),
         };
 
@@ -885,8 +912,16 @@ impl SimpleAsyncComponent for App {
             })
         };
 
+        let check_for_updates_action = {
+            let sender = sender.clone();
+            RelmAction::<CheckForUpdatesAction>::new_stateless(move |_| {
+                sender.input(AppMsg::CheckForUpdates);
+            })
+        };
+
         actions.add_action(about_action);
         actions.add_action(preferences_action);
+        actions.add_action(check_for_updates_action);
 
         actions.register_for_widget(&widgets.main_window);
 
@@ -907,6 +942,21 @@ impl SimpleAsyncComponent for App {
         } else {
             model.picture_navigation_view.set_visible(false);
             model.onboard_view.set_visible(true);
+        }
+
+        // Startup update check. Only notifies when an update is available;
+        // runs the blocking request off the UI thread.
+        if settings.update_check_enabled {
+            let sender = sender.clone();
+            relm4::spawn(async move {
+                let found = relm4::spawn_blocking(|| update_checker::check(VERSION))
+                    .await
+                    .ok()
+                    .flatten();
+                if let Some(version) = found {
+                    sender.input(AppMsg::UpdateAvailable(version));
+                }
+            });
         }
 
         AsyncComponentParts { model, widgets }
@@ -1137,6 +1187,29 @@ impl SimpleAsyncComponent for App {
                 self.picture_navigation_view.set_visible(true);
                 self.onboard_view.set_visible(false);
             }
+            AppMsg::CheckForUpdates => {
+                info!("Manually checking for updates");
+                let sender = sender.clone();
+                relm4::spawn(async move {
+                    let found = relm4::spawn_blocking(|| update_checker::check(VERSION))
+                        .await
+                        .ok()
+                        .flatten();
+                    match found {
+                        Some(version) => sender.input(AppMsg::UpdateAvailable(version)),
+                        None => sender.input(AppMsg::NoUpdateAvailable),
+                    }
+                });
+            }
+            AppMsg::UpdateAvailable(version) => {
+                info!("Update available: {}", version);
+                let toast = adw::Toast::new(&fl!("update-available", version = version));
+                self.toast_overlay.add_toast(toast);
+            }
+            AppMsg::NoUpdateAvailable => {
+                let toast = adw::Toast::new(&fl!("update-not-available"));
+                self.toast_overlay.add_toast(toast);
+            }
         }
     }
 
@@ -1161,6 +1234,7 @@ impl App {
         Ok(Settings {
             show_selfies: gio_settings.boolean("show-selfies"),
             process_motion_photos: gio_settings.boolean("process-motion-photos"),
+            update_check_enabled: gio_settings.boolean("update-check-enabled"),
             face_detection_mode: FaceDetectionMode::from_str(
                 &gio_settings.string("face-detection-mode"),
             )
@@ -1177,6 +1251,7 @@ impl App {
         let gio_settings = gio::Settings::new(APP_ID);
         gio_settings.set_boolean("show-selfies", settings.show_selfies)?;
         gio_settings.set_boolean("process-motion-photos", settings.process_motion_photos)?;
+        gio_settings.set_boolean("update-check-enabled", settings.update_check_enabled)?;
         gio_settings.set_string("face-detection-mode", settings.face_detection_mode.as_ref())?;
         gio_settings.set_string("album-sort", settings.album_sort.as_ref())?;
         gio_settings.set_boolean("onboarding-complete", settings.is_onboarding_complete)?;

--- a/src/app/update_checker.rs
+++ b/src/app/update_checker.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2024 David Bliss
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Checks GitHub for a newer Fotema release.
+//!
+//! Uses a blocking `ureq` request so it must be run off the UI thread
+//! (e.g. via `relm4::spawn_blocking`), avoiding any async-runtime/reactor
+//! coupling with the glib main loop.
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use tracing::warn;
+
+const GITHUB_API: &str = "https://api.github.com/repos/blissd/fotema/releases/latest";
+
+#[derive(Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+}
+
+/// Returns `Some(latest_version)` if GitHub reports a release newer than
+/// `installed`, otherwise `None` (also on any network/parse error).
+pub fn check(installed: &str) -> Option<String> {
+    let user_agent = format!("Fotema/{installed}");
+
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(5)))
+        .user_agent(user_agent)
+        .build()
+        .into();
+
+    let release: GitHubRelease = match agent.get(GITHUB_API).call() {
+        Ok(mut resp) => match resp.body_mut().read_json() {
+            Ok(release) => release,
+            Err(e) => {
+                warn!("Failed to parse GitHub release response: {e}");
+                return None;
+            }
+        },
+        Err(e) => {
+            warn!("Update check request failed: {e}");
+            return None;
+        }
+    };
+
+    let latest = release
+        .tag_name
+        .strip_prefix('v')
+        .unwrap_or(&release.tag_name);
+
+    if is_newer(latest, installed) {
+        Some(latest.to_string())
+    } else {
+        None
+    }
+}
+
+/// Numeric, segment-wise semver comparison. Missing segments count as 0, so
+/// patch releases (2.4.2 -> 2.4.3) are detected, not just major/minor.
+fn is_newer(latest: &str, installed: &str) -> bool {
+    let parse = |v: &str| -> Vec<u32> { v.split('.').filter_map(|p| p.parse().ok()).collect() };
+    let latest = parse(latest);
+    let installed = parse(installed);
+
+    let len = latest.len().max(installed.len());
+    for i in 0..len {
+        let l = latest.get(i).copied().unwrap_or(0);
+        let n = installed.get(i).copied().unwrap_or(0);
+        if l != n {
+            return l > n;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_newer;
+
+    #[test]
+    fn detects_newer_versions() {
+        assert!(is_newer("2.5.0", "2.4.2"));
+        assert!(is_newer("2.4.3", "2.4.2")); // patch update detected
+        assert!(is_newer("3.0.0", "2.9.9"));
+        assert!(is_newer("2.4", "2.3.9"));
+    }
+
+    #[test]
+    fn rejects_same_or_older() {
+        assert!(!is_newer("2.4.2", "2.4.2"));
+        assert!(!is_newer("2.4.1", "2.4.2"));
+        assert!(!is_newer("2.4.2", "2.4.2.0"));
+        assert!(!is_newer("1.0.0", "2.0.0"));
+    }
+}


### PR DESCRIPTION
Adds an optional, opt-in check on startup that asks the GitHub releases API
whether a newer Fotema release exists, and shows a dismissible banner/toast with
a link if so. There's a settings toggle (`update-check-enabled`, default on) to
disable it.

Implementation notes:
- The check is a small blocking request done off the UI thread via
  `relm4::spawn_blocking`, using `ureq` (lightweight blocking HTTP) + `serde` for
  the one JSON response. I used `ureq` to keep it simple and avoid pulling the
  async stack into a one-shot startup check — happy to rewrite on top of the
  existing `reqwest` dependency if you'd prefer not to add `ureq`.
- SemVer comparison incl. patch level; only newer versions trigger the banner.

Entirely optional — if an in-app update check doesn't fit how you distribute
Fotema (Flathub etc.), feel free to close this one.

Files: src/app/update_checker.rs (new), src/app.rs, data/…gschema.xml.in,
i18n/en-US/fotema.ftl, Cargo.toml (+serde, +ureq)
