### PR TITLE
perf: build photo thumbnails directly from the texture (no PNG round-trip)

### DIFF
--- a/core/src/photo/thumbnailer.rs
+++ b/core/src/photo/thumbnailer.rs
@@ -4,11 +4,8 @@
 
 use anyhow::*;
 
-use image::ImageReader;
-
 use gdk4::prelude::TextureExt;
 use glycin;
-use std::io::Cursor;
 use tracing::error;
 
 use crate::FlatpakPathBuf;
@@ -54,17 +51,35 @@ impl PhotoThumbnailer {
             err
         })?;
 
-        let bytes = frame.texture().save_to_png_bytes();
+        // Download raw RGBA pixels straight from the decoded texture instead of
+        // round-tripping through a full-resolution PNG encode + decode, which
+        // dominated photo thumbnailing (the encode alone cost more than the
+        // actual image decode).
+        let texture = frame.texture();
+        let width = texture.width() as u32;
+        let height = texture.height() as u32;
 
-        let src_image =
-            ImageReader::with_format(Cursor::new(bytes), image::ImageFormat::Png).decode()?;
-        /*
-                let _ = self.thumbnailer.generate_thumbnail(
-                    path,
-                    thumbnailify::ThumbnailSize::Large,
-                    src_image.clone(),
-                )?;
-        */
+        let mut downloader = gdk4::TextureDownloader::new(&texture);
+        downloader.set_format(gdk4::MemoryFormat::R8g8b8a8);
+        let (bytes, stride) = downloader.download_bytes();
+
+        let row_bytes = width as usize * 4;
+        let data = if stride == row_bytes {
+            bytes.to_vec()
+        } else {
+            // Strip row padding so the buffer is tightly packed for `image`.
+            let mut packed = Vec::with_capacity(row_bytes * height as usize);
+            for y in 0..height as usize {
+                let start = y * stride;
+                packed.extend_from_slice(&bytes[start..start + row_bytes]);
+            }
+            packed
+        };
+
+        let buffer = image::RgbaImage::from_raw(width, height, data)
+            .ok_or_else(|| anyhow!("Texture buffer size mismatch for {:?}", path.sandbox_path))?;
+        let src_image = image::DynamicImage::ImageRgba8(buffer);
+
         let _ = self.thumbnailer.generate_all_thumbnails(path, src_image)?;
 
         Ok(())


### PR DESCRIPTION
When generating a photo thumbnail, Fotema previously encoded the source frame to
PNG and then decoded that PNG back again before handing it to the thumbnailer.
This builds the image directly from the decoded GDK texture's raw RGBA pixels,
skipping the encode→decode round-trip entirely.

Pure performance change — the stored thumbnail format is unchanged. Noticeable on
large, photo-heavy libraries during the initial build.

Files: core/src/photo/thumbnailer.rs
