### PR TITLE
ci: build Flatpak on the large /mnt disk to avoid running out of space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: bilelmoussaoui/flatpak-github-actions:gnome-47
-      options: --privileged
+      # Mount the runner's large ephemeral disk (/mnt, ~70 GB) into the
+      # container so the build can use it (see build/state/repo-dir below).
+      options: --privileged -v /mnt:/mnt
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -28,3 +30,9 @@ jobs:
         manifest-path: build-aux/app.fotema.Fotema.Devel.json
         run-tests: true
         upload-artifact: false
+        # The OpenCV + onnxruntime build trees and the OSTree repo are several
+        # GB and overflow the runner's small root partition ("No space left on
+        # device"). Put them on the large /mnt disk mounted above.
+        build-dir: /mnt/flatpak/build
+        state-dir: /mnt/flatpak/state
+        repo-dir: /mnt/flatpak/repo


### PR DESCRIPTION
The Flatpak CI job intermittently fails with **`No space left on device`** (e.g. while building OpenCV/onnxruntime). The runner when this happens cannot even write its own diagnostic log:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/.../Worker_*.log'
```

**Cause:** GitHub `ubuntu-latest` has a small root partition (~14 GB free) where the workspace lives, and a much larger ephemeral disk at `/mnt` (~70 GB) that goes unused. The OpenCV + onnxruntime build trees (under `.flatpak-builder`/`state-dir`) plus the OSTree repo are several GB and overflow the root partition.

**Fix:** mount `/mnt` into the build container and point the flatpak-builder `build-dir`, `state-dir` and `repo-dir` at it (all are first-class inputs of `flatpak-github-actions/flatpak-builder`). No behaviour change otherwise.

This is a 9-line `ci.yml`-only change; this PR's own CI run validates it.

Note: if the runtime/SDK install (~2 GB, installed to the user flatpak dir on `/`) still pushes it over, a follow-up can additionally set `FLATPAK_USER_DIR`/`HOME` under `/mnt`.