### PR TITLE
feat: Faster thumbnails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,6 +1346,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tracing",
  "url",
+ "video-rs",
  "walkdir",
 ]
 
@@ -5506,6 +5507,18 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "video-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2633ec4c2a8aeb7c0e970f75ba99122a75841e9f7b34d5225366d0e61a870a8c"
+dependencies = [
+ "ffmpeg-next",
+ "ndarray 0.17.2",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "walkdir"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,3 +39,4 @@ md5 = "0.8.0"
 png = "0.18.0"
 thiserror = "2.0.18"
 byteorder = "1.5.0"
+video-rs = {version = "0.11", features = ["ndarray"]}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod path_encoding;
 pub mod people;
 pub mod photo;
 pub mod scanner;
+pub mod texture_utils;
 pub mod thumbnailify;
 pub mod time;
 pub mod video;

--- a/core/src/machine_learning/face_extractor.rs
+++ b/core/src/machine_learning/face_extractor.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::people::FaceDetectionCandidate;
+use crate::texture_utils;
 use crate::thumbnailify::{ThumbnailSize, Thumbnailer};
 
 use anyhow::*;
 
 use super::nms::Nms;
-use image::ImageReader;
-use std::io::Cursor;
+
 use std::path::{Path, PathBuf};
 use std::result::Result::Ok;
 
@@ -17,7 +17,6 @@ use rust_faces::{
     BlazeFaceParams, Face as DetectedFace, FaceDetection, FaceDetectorBuilder, ToArray3,
 };
 
-use gdk4::prelude::TextureExt;
 use image::DynamicImage;
 use tracing::{debug, error, info};
 
@@ -280,10 +279,7 @@ impl FaceExtractor {
         let loader = glycin::Loader::new(file);
         let image = loader.load().await?;
         let frame = image.next_frame().await?;
-        let bytes = frame.texture().save_to_png_bytes();
-        let image =
-            ImageReader::with_format(Cursor::new(bytes), image::ImageFormat::Png).decode()?;
-
+        let image = texture_utils::texture_to_rgba(frame.texture())?;
         Ok(image)
     }
 }

--- a/core/src/people/thumbnailer.rs
+++ b/core/src/people/thumbnailer.rs
@@ -6,18 +6,16 @@
 // Necessary because face thumbnails are extracted from x-large thumbnail images, which
 // makes the face thumbnails quite small.
 
-use std::io::Cursor;
 use std::path::PathBuf;
 
 use super::model::DetectedFace;
 use crate::FlatpakPathBuf;
+use crate::texture_utils;
 use crate::thumbnailify;
 use crate::thumbnailify::ThumbnailSize;
 
 use anyhow::*;
-use gdk4::prelude::TextureExt;
 use glycin;
-use image::ImageReader;
 use tracing::error;
 
 #[derive(Debug, Clone)]
@@ -148,14 +146,7 @@ impl PersonThumbnailer {
             y = 0.0;
         }
 
-        let bytes = frame.texture().save_to_png_bytes();
-
-        let original_image = ImageReader::with_format(Cursor::new(bytes), image::ImageFormat::Png)
-            .decode()
-            .map_err(|err| {
-                error!("Failed to convert to PNG: {:?}", original_picture.host_path);
-                err
-            })?;
+        let original_image = texture_utils::texture_to_rgba(frame.texture())?;
 
         // FIXME use fast_image_resize instead of image-rs
         let thumbnail = original_image.crop_imm(x as u32, y as u32, longest as u32, longest as u32);

--- a/core/src/photo/thumbnailer.rs
+++ b/core/src/photo/thumbnailer.rs
@@ -4,14 +4,12 @@
 
 use anyhow::*;
 
-use image::ImageReader;
-
-use gdk4::prelude::TextureExt;
 use glycin;
-use std::io::Cursor;
+
 use tracing::error;
 
 use crate::FlatpakPathBuf;
+use crate::texture_utils;
 use crate::thumbnailify;
 
 /// Thumbnail operations for photos.
@@ -54,17 +52,8 @@ impl PhotoThumbnailer {
             err
         })?;
 
-        let bytes = frame.texture().save_to_png_bytes();
+        let src_image = texture_utils::texture_to_rgba(frame.texture())?;
 
-        let src_image =
-            ImageReader::with_format(Cursor::new(bytes), image::ImageFormat::Png).decode()?;
-        /*
-                let _ = self.thumbnailer.generate_thumbnail(
-                    path,
-                    thumbnailify::ThumbnailSize::Large,
-                    src_image.clone(),
-                )?;
-        */
         let _ = self.thumbnailer.generate_all_thumbnails(path, src_image)?;
 
         Ok(())

--- a/core/src/texture_utils.rs
+++ b/core/src/texture_utils.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 David Bliss
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use anyhow::*;
+use gdk4::prelude::TextureExt;
+use image::DynamicImage;
+
+// Download raw RGBA pixels straight from the decoded texture instead of
+// round-tripping through a full-resolution PNG encode + decode, which
+// dominated photo thumbnailing (the encode alone cost more than the
+// actual image decode).
+pub fn texture_to_rgba(texture: gdk4::Texture) -> Result<DynamicImage> {
+    let width = texture.width() as u32;
+    let height = texture.height() as u32;
+
+    let mut downloader = gdk4::TextureDownloader::new(&texture);
+    downloader.set_format(gdk4::MemoryFormat::R8g8b8a8);
+    let (bytes, stride) = downloader.download_bytes();
+
+    let row_bytes = width as usize * 4;
+    let data = if stride == row_bytes {
+        bytes.to_vec()
+    } else {
+        // Strip row padding so the buffer is tightly packed for `image`.
+        let mut packed = Vec::with_capacity(row_bytes * height as usize);
+        for y in 0..height as usize {
+            let start = y * stride;
+            packed.extend_from_slice(&bytes[start..start + row_bytes]);
+        }
+        packed
+    };
+
+    let buffer = image::RgbaImage::from_raw(width, height, data)
+        .ok_or_else(|| anyhow!("Texture buffer size mismatch"))?;
+    Ok(image::DynamicImage::ImageRgba8(buffer))
+}

--- a/core/src/video/metadata.rs
+++ b/core/src/video/metadata.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use std::result::Result::Ok;
 
 use std::fs;
+use tracing::debug;
 
 /// This version number should be incremented each time metadata scanning has
 /// a bug fix or feature addition that changes the metadata produced.
@@ -81,7 +82,7 @@ pub fn from_path(path: &Path) -> Result<Metadata> {
 
         if !f64::is_nan(rotation) {
             metadata.rotation = Some(rotation as i32);
-            println!(
+            debug!(
                 "rotation f64={}, metadata.rotation={:?}",
                 rotation, metadata.rotation
             );

--- a/core/src/video/thumbnailer.rs
+++ b/core/src/video/thumbnailer.rs
@@ -6,18 +6,14 @@ use crate::FlatpakPathBuf;
 use crate::thumbnailify;
 use crate::video::display_matrix::av_display_rotation_get;
 
+use anyhow::Context;
 use anyhow::*;
+use image::ImageBuffer;
 use image::imageops;
-use image::{ImageBuffer, ImageFormat, ImageReader, RgbImage};
-use std::path::Path;
 use std::result::Result::Ok;
-use tempfile;
 
-use ffmpeg::format::{Pixel, input};
-use ffmpeg::media::Type;
-use ffmpeg::software::scaling::{context::Context, flag::Flags};
-use ffmpeg::util::frame::video::Video;
-use ffmpeg_next as ffmpeg;
+use video_rs::decode::Decoder;
+
 use ffmpeg_next::frame::side_data::Type as SideDataType;
 
 /// Thumbnail operations for videos.
@@ -46,80 +42,31 @@ impl VideoThumbnailer {
     pub fn thumbnail_internal(&self, path: &FlatpakPathBuf) -> Result<()> {
         // Extract first frame of video for thumbnail
 
-        // Temporary output file for frame.
-        let temporary_png_file = tempfile::Builder::new().suffix(".png").tempfile()?;
+        let mut decoder = Decoder::new(path.sandbox_path.clone())?;
 
-        // See https://docs.rs/ffmpeg-next/latest/src/dump_frames/dump-frames.rs.html
-        if let Ok(mut ictx) = input(path.sandbox_path.as_os_str()) {
-            let input = ictx
-                .streams()
-                .best(Type::Video)
-                .ok_or(ffmpeg::Error::StreamNotFound)?;
+        let (width, height) = decoder.size();
 
-            let video_stream_index = input.index();
+        // FIXME do we have to decode twice?
+        // Right now this is so we can get the image data from frame and the
+        // side-data from raw_frame.
+        let frame = decoder.decode()?.1;
+        decoder.seek(0)?;
+        let raw_frame = decoder.decode_raw()?;
 
-            let context_decoder =
-                ffmpeg::codec::context::Context::from_parameters(input.parameters())?;
-            let mut decoder = context_decoder.decoder().video()?;
+        let frame_slice = frame
+            .as_slice()
+            .context("Failed to turn frame into slice.")?;
 
-            let mut scaler = Context::get(
-                decoder.format(),
-                decoder.width(),
-                decoder.height(),
-                Pixel::RGB24,
-                decoder.width(),
-                decoder.height(),
-                Flags::BILINEAR,
-            )?;
+        let display_matrix = raw_frame.side_data(SideDataType::DisplayMatrix);
+        let rotation = if let Some(display_matrix) = display_matrix {
+            av_display_rotation_get(display_matrix.data())
+        } else {
+            f64::NAN
+        };
 
-            // Lambda for decoding video
-            let mut receive_and_process_decoded_frames =
-                |decoder: &mut ffmpeg::decoder::Video| -> Result<(), ffmpeg::Error> {
-                    let mut decoded = Video::empty();
-                    if decoder.receive_frame(&mut decoded).is_ok() {
-                        // MatrixData contains rotation.
-                        let display_matrix = decoded.side_data(SideDataType::DisplayMatrix);
-                        let rotation = if let Some(display_matrix) = display_matrix {
-                            av_display_rotation_get(display_matrix.data())
-                        } else {
-                            f64::NAN
-                        };
-
-                        let mut rgb_frame = Video::empty();
-                        scaler.run(&decoded, &mut rgb_frame)?;
-                        Self::convert_rgb_to_png(&rgb_frame, rotation, temporary_png_file.path())
-                            .map_err(|_| ffmpeg::Error::Unknown)?;
-                    }
-                    Ok(())
-                };
-
-            for (stream, packet) in ictx.packets() {
-                if stream.index() == video_stream_index {
-                    // Note to self: can also get side data and display matrix
-                    // from packet side data.
-                    decoder.send_packet(&packet)?;
-                    receive_and_process_decoded_frames(&mut decoder)?;
-                    break;
-                }
-            }
-            decoder.send_eof()?;
-            receive_and_process_decoded_frames(&mut decoder)?;
-        }
-
-        let src_image = ImageReader::open(&temporary_png_file)?.decode()?;
-
-        let _ = self.thumbnailer.generate_all_thumbnails(path, src_image)?;
-
-        Ok(())
-    }
-
-    fn convert_rgb_to_png(frame: &Video, rotation: f64, png_path: &Path) -> Result<()> {
-        let image_width = frame.width();
-        let image_height = frame.height();
-        let frame_bytes: Vec<u8> = frame.data(0).to_vec();
-
-        let buffer: RgbImage = ImageBuffer::from_raw(image_width, image_height, frame_bytes)
-            .expect("Video frame to image");
+        let buffer: ImageBuffer<image::Rgb<u8>, Vec<u8>> =
+            ImageBuffer::from_raw(width, height, frame_slice.to_vec())
+                .context("Failed to construct image buffer.")?;
 
         let buffer = match rotation {
             90.0 => imageops::rotate90(&buffer),
@@ -128,7 +75,10 @@ impl VideoThumbnailer {
             _ => buffer,
         };
 
-        buffer.save_with_format(png_path, ImageFormat::Png)?;
+        let src_image = image::DynamicImage::ImageRgb8(buffer);
+
+        let _ = self.thumbnailer.generate_all_thumbnails(path, src_image)?;
+
         Ok(())
     }
 }

--- a/core/src/video/thumbnailer.rs
+++ b/core/src/video/thumbnailer.rs
@@ -49,6 +49,10 @@ impl VideoThumbnailer {
         // FIXME do we have to decode twice?
         // Right now this is so we can get the image data from frame and the
         // side-data from raw_frame.
+        // The image data can also come from raw_frame,
+        // but If I use raw_frame.data(0).to_vec() insead of frame.as_slice(),
+        // then some frame are corrupted :-/
+
         let frame = decoder.decode()?.1;
         decoder.seek(0)?;
         let raw_frame = decoder.decode_raw()?;


### PR DESCRIPTION
Remove round-trip to PNGs when generating thumbnails, which makes generation a lot faster. Credit to [@beneedict](https://github.com/blissd/fotema/pull/681).

Use video-rs to extract video thumbnail frames. This is easier to use that ffmpeg-next and also fixes the problem of the occasional corrupt thumbnail.